### PR TITLE
[feat] swagger 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,9 @@ dependencies {
 
 	// Validation
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	//Swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.4'
 }
 
 tasks.named('test') {

--- a/src/main/java/nutshell/server/constant/AuthConstant.java
+++ b/src/main/java/nutshell/server/constant/AuthConstant.java
@@ -7,7 +7,10 @@ public class AuthConstant {
     public static final String ANONYMOUS_USER = "anonymousUser";
     public static final String[] AUTH_WHITELIST = {
             "/actuator/health",
-            "/api/**"
+            "/api/**",
+            "/v3/api-docs/**",
+            "/swagger-ui/**",
+            "/swagger-ui.html"
     };
     private AuthConstant() {
     }

--- a/src/main/java/nutshell/server/swagger/SwaggerConfig.java
+++ b/src/main/java/nutshell/server/swagger/SwaggerConfig.java
@@ -1,0 +1,25 @@
+package nutshell.server.swagger;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        Info info = new Info()
+                .title("Nutshell API")
+                .description("Nutshell Swagger dev API")
+                .version("v1");
+
+        return new OpenAPI()
+                .components(new Components())
+                .info(info);
+    }
+}
+


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #10 

## Work Description ✏️
현재 저희 프로젝트의 스프링부트 버전은 3.3.1이고 이에 맞는 swagger 버전 의존성을 추가해 주었습니다.
```Java
	//Swagger
	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.4'
```

swagger 설정 파일을 작성하였습니다.
개발을 하면서 필요한 설정을 수정하며 사용하면 됩니다.
```Java
@Configuration
public class SwaggerConfig {

    @Bean
    public OpenAPI openAPI() {
        Info info = new Info()
                .title("Nutshell API")
                .description("Nutshell Swagger dev API")
                .version("v1");

        return new OpenAPI()
                .components(new Components())
                .info(info);
    }
}
```

swagger 경로를 화이트리스트에 추가해 주었습니다.
```Java
    public static final String[] AUTH_WHITELIST = {
            "/actuator/health",
            "/api/**",
            "/v3/api-docs/**", //추가
            "/swagger-ui/**", //추가
            "/swagger-ui.html" //추가
    };
```


http://localhost:8080/swagger-ui/index.html 로 접속하면 아래와 같은 화면이 나타납니다.
![image](https://github.com/TEAM-DAWM/NUTSHELL-SERVER/assets/128598386/c7c5b9e7-b17d-4428-bde1-44fded54e4be)

swagger 어노테이션 사용시, 각 도메인 Controller에서 어노테이션을 직접 작성하지 않고, SwaggerController를 따로 인터페이스로 분리하여 사용하면 더욱 효율적인 코드가 될 것 같습니다.


## To Reviewers 📢
사용하면 편리할 것 같아서 추가해보았습니다!
