### PR TITLE
[feat] Task 할당 날짜 PATCH API 구현

### DIFF
--- a/src/main/java/nutshell/server/JacksonConfig.java
+++ b/src/main/java/nutshell/server/JacksonConfig.java
@@ -1,0 +1,19 @@
+package nutshell.server;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JacksonConfig {
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        return mapper;
+    }
+}
+

--- a/src/main/java/nutshell/server/controller/TaskController.java
+++ b/src/main/java/nutshell/server/controller/TaskController.java
@@ -2,6 +2,7 @@ package nutshell.server.controller;
 
 import lombok.RequiredArgsConstructor;
 import nutshell.server.annotation.UserId;
+import nutshell.server.dto.task.TaskAssignedDto;
 import nutshell.server.dto.task.TaskCreateDto;
 import nutshell.server.service.task.TaskService;
 import org.springframework.http.ResponseEntity;
@@ -29,6 +30,16 @@ public class TaskController {
             @PathVariable(name = "taskId") final Long taskId
     ) {
         taskService.removeTask(userId, taskId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PatchMapping("/tasks/{taskId}/assign")
+    public ResponseEntity<Void> assignedTask(
+            @UserId final Long userId,
+            @PathVariable(name="taskId") final Long taskId,
+            @RequestBody final TaskAssignedDto taskAssignedDto
+    ){
+        taskService.assignTask(userId, taskId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/nutshell/server/controller/TaskController.java
+++ b/src/main/java/nutshell/server/controller/TaskController.java
@@ -39,7 +39,7 @@ public class TaskController {
             @PathVariable(name="taskId") final Long taskId,
             @RequestBody final TaskAssignedDto taskAssignedDto
     ){
-        taskService.assignTask(userId, taskId);
+        taskService.assignTask(userId, taskId, taskAssignedDto);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/nutshell/server/dto/task/TaskAssignedDto.java
+++ b/src/main/java/nutshell/server/dto/task/TaskAssignedDto.java
@@ -1,0 +1,8 @@
+package nutshell.server.dto.task;
+
+import java.time.LocalDate;
+
+public record TaskAssignedDto(
+        LocalDate targetDate
+) {
+}

--- a/src/main/java/nutshell/server/dto/task/TaskAssignedDto.java
+++ b/src/main/java/nutshell/server/dto/task/TaskAssignedDto.java
@@ -1,8 +1,13 @@
 package nutshell.server.dto.task;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Getter;
+import lombok.ToString;
+
 import java.time.LocalDate;
 
 public record TaskAssignedDto(
+        @JsonFormat(pattern = "yyyy-MM-dd",timezone = "Asia/Seoul")
         LocalDate targetDate
 ) {
 }

--- a/src/main/java/nutshell/server/service/task/TaskService.java
+++ b/src/main/java/nutshell/server/service/task/TaskService.java
@@ -3,8 +3,8 @@ package nutshell.server.service.task;
 import lombok.RequiredArgsConstructor;
 import nutshell.server.domain.Task;
 import nutshell.server.domain.User;
+import nutshell.server.dto.task.TaskAssignedDto;
 import nutshell.server.dto.task.TaskCreateDto;
-import nutshell.server.dto.task.TaskResponse;
 import nutshell.server.service.user.UserRetriever;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,6 +20,7 @@ public class TaskService {
     private final TaskSaver taskSaver;
     private final TaskRetriever taskRetriever;
     private final TaskRemover taskRemover;
+    private final TaskUpdater taskUpdater;
 
     @Transactional
     public Task createTask(final Long userId, final TaskCreateDto taskCreateDto){
@@ -46,10 +47,13 @@ public class TaskService {
     }
 
     @Transactional
-    public void assignTask(final Long userId, final Long taskId){
+    public void assignTask(final Long userId, final Long taskId, final TaskAssignedDto taskAssignedDto){
+        if (taskAssignedDto == null) {
+            throw new IllegalArgumentException("TaskAssignedDto is null");
+        }
         User user = userRetriever.findByUserId(userId);
         Task task = taskRetriever.findTaskByTaskId(taskId);
-        task.updateAssignedDate(LocalDate.now());
+        LocalDate targetDate = taskAssignedDto.targetDate();
+        taskUpdater.updateAssignedTask(task, targetDate);
     }
-
 }

--- a/src/main/java/nutshell/server/service/task/TaskService.java
+++ b/src/main/java/nutshell/server/service/task/TaskService.java
@@ -9,6 +9,7 @@ import nutshell.server.service.user.UserRetriever;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Service
@@ -42,6 +43,14 @@ public class TaskService {
     public void removeTask(final Long userId, final Long taskId) {
         Task task = taskRetriever.findTaskByTaskId(taskId);
         taskRemover.deleteTask(task);
+    }
+
+    @Transactional
+    public void assignTask(final Long userId, final Long taskId){
+        User user = userRetriever.findByUserId(userId);
+        Task task = taskRetriever.findTaskByTaskId(taskId);
+        task.updateAssignedDate(LocalDate.now());
+        taskSaver.save(task);
     }
 
 }

--- a/src/main/java/nutshell/server/service/task/TaskService.java
+++ b/src/main/java/nutshell/server/service/task/TaskService.java
@@ -50,7 +50,6 @@ public class TaskService {
         User user = userRetriever.findByUserId(userId);
         Task task = taskRetriever.findTaskByTaskId(taskId);
         task.updateAssignedDate(LocalDate.now());
-        taskSaver.save(task);
     }
 
 }

--- a/src/main/java/nutshell/server/service/task/TaskUpdater.java
+++ b/src/main/java/nutshell/server/service/task/TaskUpdater.java
@@ -1,9 +1,19 @@
 package nutshell.server.service.task;
 
 import lombok.RequiredArgsConstructor;
+import nutshell.server.domain.Task;
+import nutshell.server.dto.task.TaskAssignedDto;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDate;
+
 @Component
-@RequiredArgsConstructor
 public class TaskUpdater {
+
+    public void updateAssignedTask(
+            final Task task,
+            final LocalDate targetDate
+    ) {
+        task.updateAssignedDate(targetDate);
+    }
 }


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #31 

## Work Description ✏️
Staging Area에서 TargetDate Area로 Task를 할당 할 때, Task가 할당 된 날짜가 속성에 추가되어야 합니다.
이를 추가하는 PATCH API를 구현하였습니다.

### TaskController
https://github.com/TEAM-DAWM/NUTSHELL-SERVER/blob/4bcea1c7a57507daf7b6d38ca30508ed7fe6f1f0/src/main/java/nutshell/server/controller/TaskController.java#L36-L44

### TaskService
https://github.com/TEAM-DAWM/NUTSHELL-SERVER/blob/4bcea1c7a57507daf7b6d38ca30508ed7fe6f1f0/src/main/java/nutshell/server/service/task/TaskService.java#L49-L58

### 실행 결과
![image](https://github.com/TEAM-DAWM/NUTSHELL-SERVER/assets/128598386/e802e4f4-b8c0-4522-9091-bef557326055)
![image](https://github.com/TEAM-DAWM/NUTSHELL-SERVER/assets/128598386/f3069c43-0d8f-442b-9744-6dd0dbf2bd8e)
데이터 그립에서도 taskId 6에 해당하는 Task에 2024-07-15이 assigned_date에 추가된 것을 확인하실 수 있습니다.

## Trouble Shooting ⚽️
스프링부트가 @JsonFormat 어노테이션을 읽지 못하여서 targetDate에 null값이 들어가는 것 같았습니다.(갑자기 왜 못읽는지는...) 이를 해결해주기 위해서 JsonConfig 설정파일을 추가해 주었습니다.
https://github.com/TEAM-DAWM/NUTSHELL-SERVER/blob/4bcea1c7a57507daf7b6d38ca30508ed7fe6f1f0/src/main/java/nutshell/server/JacksonConfig.java#L9-L18
Jackson에 JavaTimeModule을 등록합니다. 이 모듈은 LocalDate, LocalDateTime 등의 Java 8 날짜와 시간을 처리할 수 있게 합니다.

## Uncompleted Tasks 😅
JsonConfig 파일의 위치를 추후에 리팩토링 하도록 하겠습니다. 
이전 풀리퀘스트를 머지하지 않은 상태로 이 브랜치의 작업을 진행했어서 임의로 위치시켜놓은 상황입니다!

## To Reviewers 📢
~~
