### PR TITLE
[feat] Task의 상태를 수정하고, 지연 시 지연 카운팅을 하는 PATCH API 구현

### DIFF
--- a/src/main/java/nutshell/server/ServerApplication.java
+++ b/src/main/java/nutshell/server/ServerApplication.java
@@ -3,9 +3,11 @@ package nutshell.server;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableFeignClients
+@EnableScheduling
 public class ServerApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/nutshell/server/controller/TaskController.java
+++ b/src/main/java/nutshell/server/controller/TaskController.java
@@ -58,7 +58,7 @@ public class TaskController {
     public ResponseEntity<Void> editStatus(
             @UserId final Long userId,
             @PathVariable final Long taskId,
-            @RequestBody TaskStatusDto taskStatusDto
+            @RequestBody final TaskStatusDto taskStatusDto
     ){
         taskService.editStatus(userId, taskId, taskStatusDto);
         return ResponseEntity.noContent().build();

--- a/src/main/java/nutshell/server/controller/TaskController.java
+++ b/src/main/java/nutshell/server/controller/TaskController.java
@@ -5,6 +5,7 @@ import nutshell.server.annotation.UserId;
 import nutshell.server.dto.task.TaskAssignedDto;
 import nutshell.server.dto.task.TaskCreateDto;
 import nutshell.server.dto.task.TaskDto;
+import nutshell.server.dto.task.TaskStatusDto;
 import nutshell.server.service.task.TaskService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -48,8 +49,18 @@ public class TaskController {
     @GetMapping("/tasks/{taskId}")
     public ResponseEntity<TaskDto> getTask(
             @UserId final Long userId,
-            @PathVariable Long taskId
+            @PathVariable final Long taskId
     ){
         return ResponseEntity.ok(taskService.getTaskDetails(userId, taskId));
+    }
+
+    @PatchMapping("tasks/{taskId}/status")
+    public ResponseEntity<Void> editStatus(
+            @UserId final Long userId,
+            @PathVariable final Long taskId,
+            @RequestBody TaskStatusDto taskStatusDto
+    ){
+        taskService.editStatus(userId, taskId, taskStatusDto);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/nutshell/server/domain/Defer.java
+++ b/src/main/java/nutshell/server/domain/Defer.java
@@ -1,0 +1,32 @@
+package nutshell.server.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access= AccessLevel.PROTECTED)
+public class Defer {
+
+    @Id
+    @GeneratedValue(strategy= GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name="created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @ManyToOne(targetEntity = Task.class, fetch = FetchType.LAZY)
+    @JoinColumn(name="task_id", nullable = false)
+    private Task task;
+
+    @Builder
+    public Defer(Task task) {
+        this.task = task;
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/nutshell/server/domain/Task.java
+++ b/src/main/java/nutshell/server/domain/Task.java
@@ -63,6 +63,9 @@ public class Task {
     @OneToMany(mappedBy="task", fetch=FetchType.LAZY, cascade=CascadeType.ALL)
     private List<TimeBlock> timeBlocks;
 
+    @OneToMany(mappedBy="task", fetch=FetchType.LAZY, cascade=CascadeType.ALL)
+    private List<Defer> defers;
+
 
     @Builder
     public Task(User user, String name, String description, LocalDateTime deadLine) {
@@ -94,7 +97,7 @@ public class Task {
         this.status = status;
         if(status == Status.IN_PROGRESS)
             this.inprogressDate = LocalDateTime.now();
-        else if(status == Status.DONE)
+        else if (status == Status.DONE)
             this.completionDate = LocalDateTime.now();
         else if(status == Status.DEFERRED)
             this.assignedDate = null;

--- a/src/main/java/nutshell/server/dto/task/TaskStatusDto.java
+++ b/src/main/java/nutshell/server/dto/task/TaskStatusDto.java
@@ -1,0 +1,9 @@
+package nutshell.server.dto.task;
+
+import lombok.Builder;
+
+@Builder
+public record TaskStatusDto(
+        String status
+) {
+}

--- a/src/main/java/nutshell/server/dto/type/Status.java
+++ b/src/main/java/nutshell/server/dto/type/Status.java
@@ -2,6 +2,8 @@ package nutshell.server.dto.type;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import nutshell.server.exception.IllegalArgumentException;
+import nutshell.server.exception.code.IllegalArgumentErrorCode;
 
 @Getter
 @AllArgsConstructor
@@ -13,4 +15,12 @@ public enum Status {
     ;
 
     private final String content;
+
+    public static Status fromContent(String content) {
+        for (Status status : Status.values()) {
+            if (status.getContent().equals(content))
+                return status;
+        }
+        throw new IllegalArgumentException(IllegalArgumentErrorCode.INVALID_ARGUMENTS);
+    }
 }

--- a/src/main/java/nutshell/server/repository/DeferRepository.java
+++ b/src/main/java/nutshell/server/repository/DeferRepository.java
@@ -1,0 +1,7 @@
+package nutshell.server.repository;
+
+import nutshell.server.domain.Defer;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DeferRepository extends JpaRepository<Defer, Long> {
+}

--- a/src/main/java/nutshell/server/repository/TaskRepository.java
+++ b/src/main/java/nutshell/server/repository/TaskRepository.java
@@ -1,8 +1,13 @@
 package nutshell.server.repository;
 
 import nutshell.server.domain.Task;
+import nutshell.server.dto.type.Status;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
+import java.util.List;
+
 public interface TaskRepository extends JpaRepository<Task, Long> {
+    List<Task> findAllByStatusAndAssignedDateLessThan(Status status, LocalDate assignedDate);
 
 }

--- a/src/main/java/nutshell/server/service/defer/DeferSaver.java
+++ b/src/main/java/nutshell/server/service/defer/DeferSaver.java
@@ -1,0 +1,16 @@
+package nutshell.server.service.defer;
+
+import lombok.RequiredArgsConstructor;
+import nutshell.server.domain.Defer;
+import nutshell.server.repository.DeferRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DeferSaver {
+    private final DeferRepository deferRepository;
+
+    public Defer save(final Defer defer){
+        return deferRepository.save(defer);
+    }
+}

--- a/src/main/java/nutshell/server/service/task/TaskRetriever.java
+++ b/src/main/java/nutshell/server/service/task/TaskRetriever.java
@@ -2,10 +2,14 @@ package nutshell.server.service.task;
 
 import lombok.RequiredArgsConstructor;
 import nutshell.server.domain.Task;
+import nutshell.server.dto.type.Status;
 import nutshell.server.exception.NotFoundException;
 import nutshell.server.exception.code.NotFoundErrorCode;
 import nutshell.server.repository.TaskRepository;
 import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -18,4 +22,7 @@ public class TaskRetriever {
         );
     }
 
+    public List<Task> findAllByStatusAndAssignedDateLessThan(){
+        return taskRepository.findAllByStatusAndAssignedDateLessThan(Status.TODO, LocalDate.now());
+    }
 }

--- a/src/main/java/nutshell/server/service/task/TaskService.java
+++ b/src/main/java/nutshell/server/service/task/TaskService.java
@@ -1,12 +1,17 @@
 package nutshell.server.service.task;
 
 import lombok.RequiredArgsConstructor;
+import nutshell.server.domain.Defer;
 import nutshell.server.domain.Task;
 import nutshell.server.domain.User;
 import nutshell.server.dto.task.TaskAssignedDto;
 import nutshell.server.dto.task.TaskCreateDto;
 import nutshell.server.dto.task.TaskDto;
+import nutshell.server.dto.task.TaskStatusDto;
+import nutshell.server.dto.type.Status;
+import nutshell.server.service.defer.DeferSaver;
 import nutshell.server.service.user.UserRetriever;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
@@ -21,6 +26,7 @@ public class TaskService {
     private final TaskRetriever taskRetriever;
     private final TaskRemover taskRemover;
     private final TaskUpdater taskUpdater;
+    private final DeferSaver deferSaver;
 
     @Transactional
     public Task createTask(final Long userId, final TaskCreateDto taskCreateDto){
@@ -71,5 +77,29 @@ public class TaskService {
                 .deadLine(new TaskCreateDto.DeadLine(date, time))
                 .status(task.getStatus().getContent())
                 .build();
+    }
+
+    @Transactional
+    public void editStatus(final Long userId, final Long taskId, final TaskStatusDto taskStatusDto){
+        User user = userRetriever.findByUserId(userId);
+        Task task = taskRetriever.findTaskByTaskId(taskId);
+        Status status = Status.fromContent(taskStatusDto.status());
+        taskUpdater.updateStatus(task, status);
+    }
+
+    @Transactional
+    @Scheduled(cron = "*/10 * * * * *")
+    public void statusSchedule(){
+        taskRetriever.findAllByStatusAndAssignedDateLessThan()
+                .forEach(
+                        this::makeDefer
+                );
+    }
+
+    @Transactional
+    public void makeDefer(final Task task){
+        taskUpdater.updateStatus(task, Status.DEFERRED);
+        Defer defer = Defer.builder().task(task).build();
+        deferSaver.save(defer);
     }
 }

--- a/src/main/java/nutshell/server/service/task/TaskService.java
+++ b/src/main/java/nutshell/server/service/task/TaskService.java
@@ -88,7 +88,7 @@ public class TaskService {
     }
 
     @Transactional
-    @Scheduled(cron = "*/10 * * * * *")
+    @Scheduled(cron = "0 0 0 * * *")
     public void statusSchedule(){
         taskRetriever.findAllByStatusAndAssignedDateLessThan()
                 .forEach(

--- a/src/main/java/nutshell/server/service/task/TaskUpdater.java
+++ b/src/main/java/nutshell/server/service/task/TaskUpdater.java
@@ -2,18 +2,29 @@ package nutshell.server.service.task;
 
 import lombok.RequiredArgsConstructor;
 import nutshell.server.domain.Task;
-import nutshell.server.dto.task.TaskAssignedDto;
+import nutshell.server.dto.type.Status;
+import nutshell.server.repository.TaskRepository;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
 
 @Component
+@RequiredArgsConstructor
 public class TaskUpdater {
+    private final TaskRepository taskRepository;
 
     public void updateAssignedTask(
             final Task task,
             final LocalDate targetDate
     ) {
         task.updateAssignedDate(targetDate);
+    }
+
+    public void updateStatus(
+            final Task task,
+            final Status status
+    ){
+        task.updateStatus(status);
+
     }
 }


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #33

## Work Description ✏️
Task의 상태(진행중, 완료, 미완료, 지연)를 바꿔주는 PATCH API를 구현했습니다.
Task의 상태가 지연 상태로 넘어가기 위해서는 Assigned Date가 오늘보다 과거이면서, 상태가 미완료인 경우입니다. 

### TaskController
https://github.com/TEAM-DAWM/NUTSHELL-SERVER/blob/dad99d118034e76ce5e9054a6c894a3a5f660250/src/main/java/nutshell/server/controller/TaskController.java#L57-L65

### TaskService
https://github.com/TEAM-DAWM/NUTSHELL-SERVER/blob/76210d89b387e3d77f504065005827cf64ed5dac/src/main/java/nutshell/server/service/task/TaskService.java#L82-L104
- fromContent() 메서드를 통해서 요청 body의 문자열에 해당하는 Status 상수를 반환해 줍니다. 이를 통해 해당하는 요청의 상태로 바로 Task의 상태(미완료, 진행중, 완료)를 변경해 줄 수 있습니다.
- statusSchedule() 메서드를 통해서 다음날로 넘어갈 때(00시)마다 Assigned Date가 오늘보다 과거이면서, 상태가 미완료인 경우의 Task들의 상태를 '지연'으로 자동으로 변경시켜 줍니다.

### Defer 도메인 추가
- 후에 대시보드 뷰에서 지연 상태의 Task 개수가 필요하므로, Task 지연 상태를 counting 해주기 위해서 Defer 도메인을 추가하였습니다.


## Trouble Shooting ⚽️
<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->
https://github.com/TEAM-DAWM/NUTSHELL-SERVER/blob/76210d89b387e3d77f504065005827cf64ed5dac/src/main/java/nutshell/server/service/task/TaskService.java#L90-L97
처음에 이 메서드에 @Transactional 어노테이션을 붙여주지 않았을 때에는 Task 상태의 변경사항(지연)이 db에 반영되지 않았습니다. 
@Transactional을 처음에 여기 붙여주지 않은 이유는, Task별로 상태를 바꿔주는 작업을 하는 중간에 하나의 Task처리에서 예외가 발생하면 전체 트랜잭션이 롤백되어 처음으로 돌아가게 됩니다. 이는 호율성 측면에서 바람직하지 않습니다! 그래서 Task 처리를 독립적인 트랜잭션으로 실행하기 위해서(상태 변경 + Defer객체 저장 작업) makeDefer()에만 붙여주었었습니다.

그러나 이렇게 하니 db에 반영되지 않아서 statusSchedule()에 @Transactional를 달아주었더니 변경사항이 반영되었습니다. 이유를 생각해보니 taskRetriever.findAllByStatusAndAssignedDateLessThan()에서 반환된 엔티티들은 영속성 컨텍스트에서 관리되지 않기 때문에 그랬던 것 같습니다. (근데 사실 이 부분이 맞는지 이해가 완벽히 가지는 않습니다..ㅠㅠ)

### 실행결과
![image](https://github.com/TEAM-DAWM/NUTSHELL-SERVER/assets/128598386/cbbb7963-dacd-43bb-be82-5ba066581912)
![image](https://github.com/TEAM-DAWM/NUTSHELL-SERVER/assets/128598386/ef7c1c05-48a4-4330-b554-426d609a59b6)
Task 상태의 디폴트 값인 TODO에서 IN_PROGESS로 변경된 것을 확인하실 수 있습니다.

![image](https://github.com/TEAM-DAWM/NUTSHELL-SERVER/assets/128598386/6bf77972-260a-4fc6-b07f-b1e9aa00abd5)
![image](https://github.com/TEAM-DAWM/NUTSHELL-SERVER/assets/128598386/5687cbdb-fd9e-4c2f-bcf6-2a2de76c301a)
Task의 Assigned Date를 어제인 2024-07-08로 설정한 다음, statusSchedule()의 실행 주기를 10초로 설정하여 테스트 하였습니다. 10초 후 자동으로 DEFERRED 상태로 변경된 것을 확인하실 수 있습니다. (지연 상태로 넘어가면 다시 할당해야 하는 Task가 되기 때문에 Assigned Date도 사라지게 됩니다.)

## Uncompleted Tasks 😅
없습니다!

## To Reviewers 📢
트러블슈팅 관련하여 제가 이해한 게 맞을까요?
