### PR TITLE
[feat] Task의 설명을 수정하는 PATCH API 구현

### DIFF
--- a/src/main/java/nutshell/server/controller/TaskController.java
+++ b/src/main/java/nutshell/server/controller/TaskController.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import nutshell.server.annotation.UserId;
 import nutshell.server.dto.task.TaskAssignedDto;
 import nutshell.server.dto.task.TaskCreateDto;
+import nutshell.server.dto.task.TaskDetailEditDto;
 import nutshell.server.dto.task.TaskDto;
 import nutshell.server.service.task.TaskService;
 import org.springframework.http.ResponseEntity;
@@ -51,5 +52,15 @@ public class TaskController {
             @PathVariable Long taskId
     ){
         return ResponseEntity.ok(taskService.getTaskDetails(userId, taskId));
+    }
+
+    @PatchMapping("/tasks/{taskId}")
+    public ResponseEntity<Void> editDetail(
+            @UserId final Long userId,
+            @PathVariable final Long taskId,
+            @RequestBody(required = false) final TaskDetailEditDto taskDetailEditDto
+    ){
+        taskService.editDetail(userId, taskId, taskDetailEditDto);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/nutshell/server/domain/Task.java
+++ b/src/main/java/nutshell/server/domain/Task.java
@@ -75,7 +75,7 @@ public class Task {
         this.updatedAt = LocalDateTime.now();
     }
 
-    public void updateTask(String name, String description, LocalDateTime deadLine) {
+    public void updateTask(String name, String description, LocalDateTime deadLine, LocalDateTime startTime, LocalDateTime endTime) {
         if (name != null)
             this.name = name;
         if (description != null)

--- a/src/main/java/nutshell/server/domain/Task.java
+++ b/src/main/java/nutshell/server/domain/Task.java
@@ -75,7 +75,7 @@ public class Task {
         this.updatedAt = LocalDateTime.now();
     }
 
-    public void updateTask(String name, String description, LocalDateTime deadLine, LocalDateTime startTime, LocalDateTime endTime) {
+    public void updateTask(String name, String description, LocalDateTime deadLine) {
         if (name != null)
             this.name = name;
         if (description != null)

--- a/src/main/java/nutshell/server/dto/task/TaskDetailEditDto.java
+++ b/src/main/java/nutshell/server/dto/task/TaskDetailEditDto.java
@@ -7,10 +7,6 @@ import java.time.LocalDateTime;
 public record TaskDetailEditDto(
         String name,
         String description,
-        TaskCreateDto.DeadLine deadLine,
-        @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm", timezone = "Asia/Seoul")
-        LocalDateTime startTime,
-        @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm", timezone = "Asia/Seoul")
-        LocalDateTime endTime
+        TaskCreateDto.DeadLine deadLine
 ) {
 }

--- a/src/main/java/nutshell/server/dto/task/TaskDetailEditDto.java
+++ b/src/main/java/nutshell/server/dto/task/TaskDetailEditDto.java
@@ -1,0 +1,16 @@
+package nutshell.server.dto.task;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDateTime;
+
+public record TaskDetailEditDto(
+        String name,
+        String description,
+        TaskCreateDto.DeadLine deadLine,
+        @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm", timezone = "Asia/Seoul")
+        LocalDateTime startTime,
+        @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm", timezone = "Asia/Seoul")
+        LocalDateTime endTime
+) {
+}

--- a/src/main/java/nutshell/server/dto/task/TaskResponse.java
+++ b/src/main/java/nutshell/server/dto/task/TaskResponse.java
@@ -9,7 +9,7 @@ import java.time.LocalDateTime;
 public record TaskResponse(
         Long id,
         String name,
-        @JsonFormat(pattern = "yyyy-MM-dd'T'hh-mm", timezone = "Asia/Seoul")
+        @JsonFormat(pattern = "yyyy-MM-dd'T'HH-mm", timezone = "Asia/Seoul")
         LocalDateTime deadLine,
         String status
 ) {

--- a/src/main/java/nutshell/server/service/task/TaskService.java
+++ b/src/main/java/nutshell/server/service/task/TaskService.java
@@ -5,6 +5,7 @@ import nutshell.server.domain.Task;
 import nutshell.server.domain.User;
 import nutshell.server.dto.task.TaskAssignedDto;
 import nutshell.server.dto.task.TaskCreateDto;
+import nutshell.server.dto.task.TaskDetailEditDto;
 import nutshell.server.dto.task.TaskDto;
 import nutshell.server.service.user.UserRetriever;
 import org.springframework.stereotype.Service;
@@ -31,7 +32,7 @@ public class TaskService {
                         Integer.parseInt(taskCreateDto.deadLine().time().split(":")[0]),
                         Integer.parseInt(taskCreateDto.deadLine().time().split(":")[1])
                 )
-                : null; //null 체크 안하면 에러남!
+                : null;
 
         Task task = Task.builder()
                 .user(user)
@@ -71,5 +72,12 @@ public class TaskService {
                 .deadLine(new TaskCreateDto.DeadLine(date, time))
                 .status(task.getStatus().getContent())
                 .build();
+    }
+
+    @Transactional
+    public void editDetail(final Long userId, final Long taskId, TaskDetailEditDto taskDetailEditDto){
+        User user = userRetriever.findByUserId(userId);
+        Task task = taskRetriever.findTaskByTaskId(taskId);
+        taskUpdater.editDetails(task, taskDetailEditDto);
     }
 }

--- a/src/main/java/nutshell/server/service/task/TaskUpdater.java
+++ b/src/main/java/nutshell/server/service/task/TaskUpdater.java
@@ -1,11 +1,13 @@
 package nutshell.server.service.task;
 
-import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import nutshell.server.domain.Task;
-import nutshell.server.dto.task.TaskAssignedDto;
+import nutshell.server.dto.task.TaskDetailEditDto;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 @Component
 public class TaskUpdater {
@@ -16,4 +18,19 @@ public class TaskUpdater {
     ) {
         task.updateAssignedDate(targetDate);
     }
+
+    public void editDetails(
+            final Task task,
+            final TaskDetailEditDto taskDetailEditDto
+    ) {
+        LocalDate date = taskDetailEditDto.deadLine().date();
+        String time = taskDetailEditDto.deadLine().time();
+
+        String dateTimeString = date.toString() + "T" + time;
+        LocalDateTime deadLine = LocalDateTime.parse(dateTimeString, DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm"));
+
+        task.updateTask(taskDetailEditDto.name(), taskDetailEditDto.description(), deadLine,
+                taskDetailEditDto.startTime(), taskDetailEditDto.endTime());
+    }
+
 }

--- a/src/main/java/nutshell/server/service/task/TaskUpdater.java
+++ b/src/main/java/nutshell/server/service/task/TaskUpdater.java
@@ -29,8 +29,7 @@ public class TaskUpdater {
         String dateTimeString = date.toString() + "T" + time;
         LocalDateTime deadLine = LocalDateTime.parse(dateTimeString, DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm"));
 
-        task.updateTask(taskDetailEditDto.name(), taskDetailEditDto.description(), deadLine,
-                taskDetailEditDto.startTime(), taskDetailEditDto.endTime());
+        task.updateTask(taskDetailEditDto.name(), taskDetailEditDto.description(), deadLine);
     }
 
 }


### PR DESCRIPTION
## Related issue 🛠
<!-- 관련 이슈 번호를 적어주세요 -->
- closes #34 

&nbsp;

## Work Description ✏️
<!-- 작업 내용을 간단히 소개주세요 -->

### TaskController
https://github.com/TEAM-DAWM/NUTSHELL-SERVER/blob/6e8632703816384cebfb25be7c8d045788cb40bc/src/main/java/nutshell/server/controller/TaskController.java#L57-L65

&nbsp;

### TaskService
https://github.com/TEAM-DAWM/NUTSHELL-SERVER/blob/6e8632703816384cebfb25be7c8d045788cb40bc/src/main/java/nutshell/server/service/task/TaskService.java#L77-L82

&nbsp;

### 실행 결과
![image](https://github.com/TEAM-DAWM/NUTSHELL-SERVER/assets/128598386/cd756bd4-980c-4340-9e29-27a0a131359b)
![image](https://github.com/TEAM-DAWM/NUTSHELL-SERVER/assets/128598386/8d3102af-4c44-4c79-a81b-3fc0562870ea)
데이터 그립에서도 설명이 수정된 것을 확인하실 수 있습니다.

&nbsp;

## To Reviewers 📢
일단 Task 엔티티의 updateTask() 메서드에 startTime, endTime 매개변수 추가하고 값 넘기기만 해뒀습니다! 
타임블로킹 부분 관련해서 구현하실 때 이 점 확인하시면 될 것 같아요.
