### PR TITLE
[fix] Task 상세 조회 GET API의 Response Body에 timeBlock 추가 

### DIFF
--- a/src/main/java/nutshell/server/controller/TaskController.java
+++ b/src/main/java/nutshell/server/controller/TaskController.java
@@ -49,7 +49,7 @@ public class TaskController {
     @GetMapping("/tasks/{taskId}")
     public ResponseEntity<TaskDto> getTask(
             @UserId final Long userId,
-            @PathVariable Long taskId
+            @PathVariable final Long taskId
     ){
         return ResponseEntity.ok(taskService.getTaskDetails(userId, taskId));
     }

--- a/src/main/java/nutshell/server/controller/TaskController.java
+++ b/src/main/java/nutshell/server/controller/TaskController.java
@@ -2,10 +2,7 @@ package nutshell.server.controller;
 
 import lombok.RequiredArgsConstructor;
 import nutshell.server.annotation.UserId;
-import nutshell.server.dto.task.TaskAssignedDto;
-import nutshell.server.dto.task.TaskCreateDto;
-import nutshell.server.dto.task.TaskDetailEditDto;
-import nutshell.server.dto.task.TaskDto;
+import nutshell.server.dto.task.*;
 import nutshell.server.service.task.TaskService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -49,9 +46,10 @@ public class TaskController {
     @GetMapping("/tasks/{taskId}")
     public ResponseEntity<TaskDto> getTask(
             @UserId final Long userId,
-            @PathVariable final Long taskId
+            @PathVariable final Long taskId,
+            @RequestBody final TargetDateDto targetDateDto
     ){
-        return ResponseEntity.ok(taskService.getTaskDetails(userId, taskId));
+        return ResponseEntity.ok(taskService.getTaskDetails(userId, taskId, targetDateDto));
     }
 
     @PatchMapping("/tasks/{taskId}")

--- a/src/main/java/nutshell/server/domain/TimeBlock.java
+++ b/src/main/java/nutshell/server/domain/TimeBlock.java
@@ -14,31 +14,27 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access= AccessLevel.PROTECTED)
 public class TimeBlock {
     @Id
-    @GeneratedValue(strategy= GenerationType.IDENTITY)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name="date", nullable = false)
-    private LocalDate date;
+    @Column(name = "start_time", nullable = false)
+    private LocalDateTime startTime;
 
-    @Column(name="start_time", nullable = false)
-    private String startTime;
+    @Column(name = "end_time", nullable = false)
+    private LocalDateTime endTime;
 
-    @Column(name="end_time", nullable = false)
-    private String endTime;
-
-    @Column(name="created_at", nullable = false)
+    @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
 
-    @Column(name="updated_at", nullable = false)
+    @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
 
-    @ManyToOne(targetEntity= Task.class, fetch=FetchType.LAZY)
-    @JoinColumn(name="task_id", nullable = false)
+    @ManyToOne(targetEntity = Task.class, fetch = FetchType.LAZY)
+    @JoinColumn(name = "task_id", nullable = false)
     private Task task;
 
     @Builder
-    public TimeBlock(LocalDate date, String startTime, String endTime, Task task) {
-        this.date = date;
+    public TimeBlock(LocalDateTime startTime, LocalDateTime endTime, Task task) {
         this.startTime = startTime;
         this.endTime = endTime;
         this.task = task;
@@ -47,7 +43,7 @@ public class TimeBlock {
     }
 
     @Builder
-    public void updateTimeBlock(String startTime, String endTime) {
+    public void updateTimeBlock(LocalDateTime startTime, LocalDateTime endTime) {
         this.startTime = startTime;
         this.endTime = endTime;
         this.updatedAt = LocalDateTime.now();

--- a/src/main/java/nutshell/server/dto/task/TargetDateDto.java
+++ b/src/main/java/nutshell/server/dto/task/TargetDateDto.java
@@ -1,0 +1,11 @@
+package nutshell.server.dto.task;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDate;
+
+public record TargetDateDto(
+        @JsonFormat(pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+        LocalDate targetDate
+) {
+}

--- a/src/main/java/nutshell/server/dto/task/TaskDto.java
+++ b/src/main/java/nutshell/server/dto/task/TaskDto.java
@@ -1,11 +1,24 @@
 package nutshell.server.dto.task;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Builder;
+
+import java.time.LocalDateTime;
 
 @Builder
 public record TaskDto(
         String name,
         String description,
         TaskCreateDto.DeadLine deadLine,
-        String status
+        String status,
+        TimeBlock timeBlock
+
 ) {
+    @Builder
+    public record TimeBlock(
+      Long id,
+      @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm", timezone = "Asia/Seoul")
+      LocalDateTime startTime,
+      @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm", timezone = "Asia/Seoul")
+      LocalDateTime endTime
+    ){}
 }

--- a/src/main/java/nutshell/server/exception/code/NotFoundErrorCode.java
+++ b/src/main/java/nutshell/server/exception/code/NotFoundErrorCode.java
@@ -12,6 +12,7 @@ public enum NotFoundErrorCode implements DefaultErrorCode{
     NOT_FOUND_TASK(HttpStatus.NOT_FOUND, "error", "존재하지 않는 Task 입니다."),
     NOT_FOUND_USER(HttpStatus.NOT_FOUND,"error","존재하지 않는 사용자 입니다."),
     NOT_FOUND_REFRESH_TOKEN(HttpStatus.NOT_FOUND, "error","리프레시 토큰을 찾을 수 없습니다."),
+    NOT_FOUND_TIMEBLOCK(HttpStatus.NOT_FOUND,"error","해당하는 날짜의 타임블록을 찾을 수 없습니다.")
     ;
 
     @JsonIgnore

--- a/src/main/java/nutshell/server/repository/TimeBlockRepository.java
+++ b/src/main/java/nutshell/server/repository/TimeBlockRepository.java
@@ -1,0 +1,21 @@
+package nutshell.server.repository;
+
+import nutshell.server.domain.Task;
+import nutshell.server.domain.TimeBlock;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+public interface TimeBlockRepository extends JpaRepository<TimeBlock, Long> {
+
+    @Query(value = "SELECT t FROM TimeBlock t WHERE t.task = :task " +
+            "and t.startTime >= :targetDate and t.startTime <= :tomorrow " +
+            "and t.endTime >= :targetDate and t.endTime <= :tomorrow")
+    Optional<TimeBlock> findByTaskIdAndTargetDate(
+            final Task task,
+            final LocalDateTime targetDate,
+            final LocalDateTime tomorrow
+    );
+}

--- a/src/main/java/nutshell/server/service/timeblock/TimeBlockRetriever.java
+++ b/src/main/java/nutshell/server/service/timeblock/TimeBlockRetriever.java
@@ -1,0 +1,23 @@
+package nutshell.server.service.timeblock;
+
+import lombok.RequiredArgsConstructor;
+import nutshell.server.domain.Task;
+import nutshell.server.domain.TimeBlock;
+import nutshell.server.repository.TimeBlockRepository;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+public class TimeBlockRetriever {
+
+    private final TimeBlockRepository timeBlockRepository;
+
+    public TimeBlock findByTaskIdAndTargetDate(final Task task, final LocalDate targetDate){
+        LocalDateTime td = targetDate.atStartOfDay();
+        LocalDateTime tomorrow = targetDate.atTime(23, 59, 59);
+        return timeBlockRepository.findByTaskIdAndTargetDate(task, td, tomorrow).orElse(null);
+    }
+}


### PR DESCRIPTION
## Related issue 🛠
<!-- 관련 이슈 번호를 적어주세요 -->
- closes #41 

&nbsp;

## Work Description ✏️
<!-- 작업 내용을 간단히 소개주세요 -->

Task를 상세 조회하는 API에서 Task를 타임블로킹 한 시간도 표시되어야 하므로, timeBlock에 대한 정보도 받아오도록 했습니다.

### TaskController
https://github.com/TEAM-DAWM/NUTSHELL-SERVER/blob/a5c474e3f02ce7017140d01c99eabc1bcec403ca/src/main/java/nutshell/server/controller/TaskController.java#L55-L63
targetDate에 해당하는 timeBlock을 가져와야 하므로 Request Body에 targetDate를 추가해주었습니다.

&nbsp;

### TimeBlockRetriever
https://github.com/TEAM-DAWM/NUTSHELL-SERVER/blob/a5c474e3f02ce7017140d01c99eabc1bcec403ca/src/main/java/nutshell/server/service/timeblock/TimeBlockRetriever.java#L12-L22
target date가 2024-07-07 이면, 2024-07-07T00:00, 2024-07-07T23:59 만들어 주어야 합니다. 이걸 사용해서 이 두 시간 사이에 있는 timeblock을 찾아올 수 있습니다.

&nbsp;

### TimeBlockRepository
https://github.com/TEAM-DAWM/NUTSHELL-SERVER/blob/a5c474e3f02ce7017140d01c99eabc1bcec403ca/src/main/java/nutshell/server/repository/TimeBlockRepository.java#L11-L20

&nbsp;

### 실행결과
![image](https://github.com/TEAM-DAWM/NUTSHELL-SERVER/assets/128598386/af0e1961-84c7-433e-98ff-9295ae4f7bfd)
1번 Task의 시작 시간과 끝 시간이 2024-06.30T2:48 ~ 2024-06.30T5:47 까지입니다.
&nbsp;

![image](https://github.com/TEAM-DAWM/NUTSHELL-SERVER/assets/128598386/56b96cfc-4dc7-41b8-b1b1-24575373d925)
tartgetDate를 2024-06-30 으로 하면 이 타겟 날짜에 해당하는 위에서 본 타임블록의 시작, 끝 시간이 응답에 담겨 있는 것을 확인하실 수 있습니다.
&nbsp;

![image](https://github.com/TEAM-DAWM/NUTSHELL-SERVER/assets/128598386/f49e9dd1-f065-4115-94fd-515a9adca9d5)
targetDate를 2024-06-29로 하면 이 타겟 날짜에는 아무런 타임블록이 존재하지 않기 때문에  null 값이 응답에 담겨 오는 것을 확인하실 수 있습니다.
&nbsp;

## To Reviewers 📢
지금 배가 너무 부르네요