### PR TITLE
[feat] Task type별 리스트 조회 GET API 구현

### DIFF
--- a/src/main/java/nutshell/server/controller/TaskController.java
+++ b/src/main/java/nutshell/server/controller/TaskController.java
@@ -2,6 +2,7 @@ package nutshell.server.controller;
 
 import lombok.RequiredArgsConstructor;
 import nutshell.server.annotation.UserId;
+import nutshell.server.dto.task.TodoTaskDto;
 import nutshell.server.dto.task.TaskAssignedDto;
 import nutshell.server.dto.task.TaskCreateDto;
 import nutshell.server.dto.task.TaskDetailEditDto;
@@ -62,8 +63,9 @@ public class TaskController {
             @RequestBody final TaskStatusDto taskStatusDto
     ){
         taskService.editStatus(userId, taskId, taskStatusDto);
-      }
-  
+        return ResponseEntity.noContent().build();
+    }
+
     @PatchMapping("/tasks/{taskId}")
     public ResponseEntity<Void> editDetail(
             @UserId final Long userId,
@@ -73,4 +75,13 @@ public class TaskController {
         taskService.editDetail(userId, taskId, taskDetailEditDto);
         return ResponseEntity.noContent().build();
     }
+
+    @GetMapping("/tasks/today")
+    public ResponseEntity<TodoTaskDto> showTaskType(
+            @UserId final Long userId,
+            @RequestParam String type
+    ){
+        return ResponseEntity.ok(taskService.getTasksOfType(userId, type));
+    }
+
 }

--- a/src/main/java/nutshell/server/dto/task/TodoTaskDto.java
+++ b/src/main/java/nutshell/server/dto/task/TodoTaskDto.java
@@ -1,0 +1,17 @@
+package nutshell.server.dto.task;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record TodoTaskDto(
+        List<TaskComponentDto> tasks
+) {
+    @Builder
+    public record TaskComponentDto(
+            Long id,
+            String name,
+            TaskCreateDto.DeadLine deadLine
+    ) { }
+}

--- a/src/main/java/nutshell/server/exception/code/NotFoundErrorCode.java
+++ b/src/main/java/nutshell/server/exception/code/NotFoundErrorCode.java
@@ -12,6 +12,7 @@ public enum NotFoundErrorCode implements DefaultErrorCode{
     NOT_FOUND_TASK(HttpStatus.NOT_FOUND, "error", "존재하지 않는 Task 입니다."),
     NOT_FOUND_USER(HttpStatus.NOT_FOUND,"error","존재하지 않는 사용자 입니다."),
     NOT_FOUND_REFRESH_TOKEN(HttpStatus.NOT_FOUND, "error","리프레시 토큰을 찾을 수 없습니다."),
+    NOT_FOUND_TASK_TYPE(HttpStatus.NOT_FOUND,"error","해당하는 Task의 type을 찾을 수 없습니다.")
     ;
 
     @JsonIgnore

--- a/src/main/java/nutshell/server/repository/TaskRepository.java
+++ b/src/main/java/nutshell/server/repository/TaskRepository.java
@@ -5,10 +5,37 @@ import nutshell.server.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 import nutshell.server.dto.type.Status;
-import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
 import java.time.LocalDate;
 import java.util.List;
 
 public interface TaskRepository extends JpaRepository<Task, Long> {
+    List<Task> findAllByStatusAndAssignedDateLessThan(Status status, LocalDate assignedDate);
     Optional<Task> findByUserAndId(final User user, final Long id);
+
+    @Query(
+            value = "select * from task t where t.user_id = :userId " +
+                    "AND t.assigned_date is null " +
+                    "AND t.dead_line <= now() + interval '2 days' " +
+                    "order by t.dead_line asc nulls last"
+            ,nativeQuery = true
+    )
+    List<Task> findAllUpcomingTasksByUserWitAssignedStatus(final Long userId);
+
+    @Query(
+            value = "select * from task t where t.user_id = :userId " +
+                    "AND t.status = 'IN_PROGRESS' " +
+                    "order by t.dead_line nulls last"
+            ,nativeQuery = true
+    )
+    List<Task> findAllInprogressTasksByUserWithStatus(final Long userId);
+
+    @Query(
+            value = "select * from task t where t.user_id = :userId " +
+                    "AND t.status = 'DEFERRED' " +
+                    "order by t.dead_line nulls last"
+            ,nativeQuery = true
+    )
+    List<Task> findAllDeferredTasksByUserWithStatus(final Long userId);
 }

--- a/src/main/java/nutshell/server/service/task/TaskRetriever.java
+++ b/src/main/java/nutshell/server/service/task/TaskRetriever.java
@@ -27,4 +27,17 @@ public class TaskRetriever {
         return taskRepository.findAllByStatusAndAssignedDateLessThan(Status.TODO, LocalDate.now());
     }
 
+    public List<Task> findAllUpcomingTasksByUserWitAssignedStatus(final Long userId){
+        return taskRepository.findAllUpcomingTasksByUserWitAssignedStatus(userId);
+    }
+
+    public List<Task> findAllInprogressTasksByUserWithStatus(final Long userId){
+        return taskRepository.findAllInprogressTasksByUserWithStatus(userId);
+    }
+
+    public List<Task> findAllDeferredTasksByUserWithStatus(final Long userId){
+        return taskRepository.findAllDeferredTasksByUserWithStatus(userId);
+    }
+
+
 }

--- a/src/main/java/nutshell/server/service/task/TaskUpdater.java
+++ b/src/main/java/nutshell/server/service/task/TaskUpdater.java
@@ -1,6 +1,6 @@
 package nutshell.server.service.task;
 
-import lombok.extern.slf4j.Slf4j;
+import lombok.RequiredArgsConstructor;
 import nutshell.server.domain.Task;
 import nutshell.server.dto.type.Status;
 import nutshell.server.repository.TaskRepository;


### PR DESCRIPTION
## Related issue 🛠
- closes #37 

&nbsp; 

## Work Description ✏️
Today를 기준으로 하여 task의 type별 리스트를 조회하는 GET API를 구현했습니다.
&nbsp; 
- 다가오는 할 일 = {Today} 기준으로 {Deadline} 이 2일 이내로 남았는데, 아직 Assign 안된 Task들이 리스팅
- 진행중인 할 일 = 진행중 상태 가지고 있는 애들 모두
- 지연된 할 일 = 지연 상태 가지고 있는 애들 모두 `// 지연된 할 일 : assignedDate != today`
→ 모두 {Deadline}이 현재와 가까운 순으로 리스팅 :: 즉, deadLine이 오름차순

&nbsp; 

### TaskRepository
https://github.com/TEAM-DAWM/NUTSHELL-SERVER/blob/d773005709c3a94bdc31d0f7dfd4a8636b77db7e/src/main/java/nutshell/server/repository/TaskRepository.java#L17-L40

&nbsp; 

---

&nbsp; 

### 다가오는 일(upcoming) 리스트 조회
 {Today} 기준으로 {Deadline} 이 2일 이내로 남았는데, 아직 Assign 안된 Task들이 리스팅됩니다.
즉, DeadLine - Now < 2 이면서 Assigned Date = null 인 Task만 보이게 됩니다!

&nbsp; 

### 실행결과
![image](https://github.com/TEAM-DAWM/NUTSHELL-SERVER/assets/128598386/2706124f-9722-404b-8387-45b5e60a9581)
![image](https://github.com/TEAM-DAWM/NUTSHELL-SERVER/assets/128598386/42cb1425-4103-4740-ae28-e5b55ba81530)
지금(2024-07-11, 1시 57분) 기준으로 deadLine이 2일 이내이고, assigned date가 null인 task 들을 받아옵니다.deadLine은 오름차순으로 정렬되도록 하였습니다. 
2024-07-11, 1시 56분에 테스트 했을 때는 deadLine이 2024-07-13, 1시 57분인 Task는 뜨지 않는 것도 확인하였습니다!!

&nbsp; 

![image](https://github.com/TEAM-DAWM/NUTSHELL-SERVER/assets/128598386/a08c57c3-7a59-41fe-89aa-e3208cee2d9d)
![image](https://github.com/TEAM-DAWM/NUTSHELL-SERVER/assets/128598386/87f9c441-41fd-45c3-8a7b-2559f4d8c554)
assignedDate가 있으면 나타나지 않는 것을 확인하실 수 있습니다!

&nbsp; 

---

&nbsp; 

### 진행중인 할 일(inprogress) 리스트 조회
진행중 상태를 가지고 있는 Task들이 모두 리스팅 됩니다.

&nbsp; 

### 실행결과
![image](https://github.com/TEAM-DAWM/NUTSHELL-SERVER/assets/128598386/ca2d4f03-ff62-4c5e-b53c-a846858ac908)
![image](https://github.com/TEAM-DAWM/NUTSHELL-SERVER/assets/128598386/17fbe100-5b82-4c63-9f86-81a7af8f6d41)
task1, task5 제목을 가진 Task들이 나타난 것을 확인하실 수 있습니다.


---

&nbsp; 

### 지연된 할 일(deferred) 리스트 조회
지연 상태를 가지고 있는 Task들이 모두 리스팅 됩니다.

&nbsp; 

### 실행결과
![image](https://github.com/TEAM-DAWM/NUTSHELL-SERVER/assets/128598386/4df9874e-d144-4f80-9262-2be55f7b4883)
![image](https://github.com/TEAM-DAWM/NUTSHELL-SERVER/assets/128598386/5c58e92c-d431-4621-a6bd-332f920db422)
task2, task4 제목을 가진 Task들이 나타난 것을 확인하실 수 있습니다.



&nbsp; 

## To Reviewers 📢
List<Task> findAllInprogressTasksByUserWithStatus(final Long userId); 
이렇게 쿼리문을 짤 때, TaskRepository에서는 매개변수로 user를 넘기지 않는 이상 userId로 task 찾을려면 무조건 직접 쿼리문 짜야하는게 맞나용? User는 있어도 UserId 항목이 없던데!
