### PR TITLE
[feat] Task List 조회 API 구현

### DIFF
--- a/src/main/java/nutshell/server/controller/TaskController.java
+++ b/src/main/java/nutshell/server/controller/TaskController.java
@@ -1,14 +1,17 @@
 package nutshell.server.controller;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.RequiredArgsConstructor;
 import nutshell.server.annotation.UserId;
 import nutshell.server.dto.task.TaskStatusDto;
 import nutshell.server.dto.task.TaskCreateDto;
+import nutshell.server.dto.task.TasksDto;
 import nutshell.server.service.task.TaskService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
+import java.time.LocalDate;
 
 @RestController
 @RequiredArgsConstructor
@@ -43,5 +46,15 @@ public class TaskController {
     ){
         taskService.removeTask(userId, taskId);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/tasks")
+    public ResponseEntity<TasksDto> getTasks(
+            @UserId final Long userId,
+            @RequestParam(required = false) final Boolean isTotal,
+            @RequestParam(required = false) final String order,
+            @RequestParam(required = false) @JsonFormat(pattern = "yyyy-MM-dd", timezone = "Asia/Seoul") final LocalDate targetDate
+    ){
+        return ResponseEntity.ok(taskService.getTasks(userId, isTotal, order, targetDate));
     }
 }

--- a/src/main/java/nutshell/server/dto/task/TasksDto.java
+++ b/src/main/java/nutshell/server/dto/task/TasksDto.java
@@ -1,0 +1,19 @@
+package nutshell.server.dto.task;
+
+import lombok.Builder;
+
+import java.util.List;
+@Builder
+public record TasksDto(
+        List<TaskItemDto> tasks
+) {
+    @Builder
+    public record TaskItemDto(
+            Long id,
+            String name,
+            TaskCreateDto.DeadLine deadLine,
+            Boolean hasDescription,
+            String status
+    ) {
+    }
+}

--- a/src/main/java/nutshell/server/repository/TaskRepository.java
+++ b/src/main/java/nutshell/server/repository/TaskRepository.java
@@ -3,9 +3,31 @@ package nutshell.server.repository;
 import nutshell.server.domain.Task;
 import nutshell.server.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface TaskRepository extends JpaRepository<Task, Long> {
     Optional<Task> findByUserAndId(User user, Long id);
+
+    List<Task> findAllByUserAndAssignedDateIsNullOrderByCreatedAtDesc(final User user);
+
+    List<Task> findAllByUserAndAssignedDateIsNullOrderByCreatedAtAsc(final User user);
+
+    @Query(
+            value = "select * from task t where t.user_id = :userId " +
+                    "AND t.assigned_date is null " +
+                    "order by abs(extract(epoch from now() - t.dead_line)) asc nulls last"
+            , nativeQuery = true
+    )
+    List<Task> findAllByUserAndAssignedDateIsNullOrderByTimeDiffAsc(final Long userId);
+
+    @Query(
+            value = "select * from task t where t.user_id = :userId " +
+                    "AND t.assigned_date is null " +
+                    "order by abs(extract(epoch from now() - t.dead_line)) desc nulls last"
+            , nativeQuery = true
+    )
+    List<Task> findAllByUserAndAssignedDateIsNullOrderByTimeDiffDesc(final Long userId);
 }

--- a/src/main/java/nutshell/server/repository/TaskStatusRepository.java
+++ b/src/main/java/nutshell/server/repository/TaskStatusRepository.java
@@ -2,6 +2,7 @@ package nutshell.server.repository;
 
 import nutshell.server.domain.Task;
 import nutshell.server.domain.TaskStatus;
+import nutshell.server.domain.User;
 import nutshell.server.dto.type.Status;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -33,4 +34,8 @@ public interface TaskStatusRepository extends JpaRepository<TaskStatus, Long> {
             "and ts.status is not 'DEFERRED' and ts.status is not 'DONE'"
     ,nativeQuery = true)
     List<TaskStatus> findAllByTargetDate(final LocalDate targetDate);
+
+    @Query(value = "select ts from TaskStatus ts where ts.task.user = :user and ts.targetDate = :targetDate " +
+            "and ts.status = :status order by ts.updatedAt desc, ts.task.assignedDate desc")
+    List<TaskStatus> findAllByTargetDateAndStatusDesc(final User user, final LocalDate targetDate, final Status status);
 }

--- a/src/main/java/nutshell/server/service/task/TaskRetriever.java
+++ b/src/main/java/nutshell/server/service/task/TaskRetriever.java
@@ -8,6 +8,8 @@ import nutshell.server.exception.code.NotFoundErrorCode;
 import nutshell.server.repository.TaskRepository;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+
 @Component
 @RequiredArgsConstructor
 public class TaskRetriever {
@@ -22,5 +24,19 @@ public class TaskRetriever {
         return taskRepository.findByUserAndId(user, id).orElseThrow(
                 () -> new NotFoundException(NotFoundErrorCode.NOT_FOUND_TASK)
         );
+    }
+    public List<Task> findAllByUserAndAssignedDateIsNullOrderByCreatedAtDesc(final User user){
+        return taskRepository.findAllByUserAndAssignedDateIsNullOrderByCreatedAtDesc(user);
+    }
+
+    public List<Task> findAllByUserAndAssignedDateIsNullOrderByCreatedAtAsc(final User user){
+        return taskRepository.findAllByUserAndAssignedDateIsNullOrderByCreatedAtAsc(user);
+    }
+    public List<Task> findAllByUserAndAssignedDateIsNullOrderByTimeDiffAsc(final User user){
+        return taskRepository.findAllByUserAndAssignedDateIsNullOrderByTimeDiffAsc(user.getId());
+    }
+
+    public List<Task> findAllByUserAndAssignedDateIsNullOrderByTimeDiffDesc(final User user){
+        return taskRepository.findAllByUserAndAssignedDateIsNullOrderByTimeDiffDesc(user.getId());
     }
 }

--- a/src/main/java/nutshell/server/service/task/TaskService.java
+++ b/src/main/java/nutshell/server/service/task/TaskService.java
@@ -6,6 +6,7 @@ import nutshell.server.domain.TaskStatus;
 import nutshell.server.domain.User;
 import nutshell.server.dto.task.TaskCreateDto;
 import nutshell.server.dto.task.TaskStatusDto;
+import nutshell.server.dto.task.TasksDto;
 import nutshell.server.dto.type.Status;
 import nutshell.server.exception.BusinessException;
 import nutshell.server.exception.IllegalArgumentException;
@@ -131,5 +132,57 @@ public class TaskService {
         User user= userRetriever.findByUserId(userId);
         Task task = taskRetriever.findByUserAndId(user, taskId);
         taskRemover.deleteTask(task);
+    }
+
+    public TasksDto getTasks(
+            final Long userId,
+            final Boolean isTotal,
+            final String order,
+            final LocalDate targetDate
+    ){
+        User user = userRetriever.findByUserId(userId);
+        List< TasksDto.TaskItemDto> taskItems;
+        if (targetDate != null){
+            List<TaskStatus> taskStatuses = new ArrayList<>();
+            taskStatuses.addAll(taskStatusRetriever.findAllByTargetDateAndStatusDesc(user, targetDate, Status.IN_PROGRESS));
+            taskStatuses.addAll(taskStatusRetriever.findAllByTargetDateAndStatusDesc(user, targetDate, Status.TODO));
+            taskStatuses.addAll(taskStatusRetriever.findAllByTargetDateAndStatusDesc(user, targetDate, Status.DONE));
+            taskItems = taskStatuses
+                    .stream().map(
+                            taskStatus -> TasksDto.TaskItemDto.builder()
+                                    .id(taskStatus.getTask().getId())
+                                    .name(taskStatus.getTask().getName())
+                                    .hasDescription(taskStatus.getTask().getDescription() != null)
+                                    .status(taskStatus.getStatus().getContent())
+                                    .deadLine(new TaskCreateDto.DeadLine(
+                                            taskStatus.getTask().getDeadLine().toLocalDate(),
+                                            taskStatus.getTask().getDeadLine().getHour() + ":" + taskStatus.getTask().getDeadLine().getMinute()
+                                    )).build()
+                    ).toList();
+        } else {
+            List<Task> tasks = order == null ? taskRetriever.findAllByUserAndAssignedDateIsNullOrderByCreatedAtDesc(user)
+                    :
+                    switch (order) {
+                        case "recent" -> taskRetriever.findAllByUserAndAssignedDateIsNullOrderByCreatedAtDesc(user);
+                        case "old" -> taskRetriever.findAllByUserAndAssignedDateIsNullOrderByCreatedAtAsc(user);
+                        case "near" -> taskRetriever.findAllByUserAndAssignedDateIsNullOrderByTimeDiffAsc(user);
+                        case "far" -> taskRetriever.findAllByUserAndAssignedDateIsNullOrderByTimeDiffDesc(user);
+                        default -> throw new IllegalArgumentException(IllegalArgumentErrorCode.INVALID_ARGUMENTS);
+
+                    };
+            tasks = isTotal ? tasks : tasks.stream().filter(task -> task.getStatus().equals(Status.DEFERRED)).toList();
+            taskItems = tasks.stream().map(
+                    task -> TasksDto.TaskItemDto.builder()
+                            .id(task.getId())
+                            .name(task.getName())
+                            .hasDescription(task.getDescription() != null)
+                            .status(task.getStatus().getContent())
+                            .deadLine(new TaskCreateDto.DeadLine(
+                                    task.getDeadLine().toLocalDate(),
+                                    task.getDeadLine().getHour() + ":" + task.getDeadLine().getMinute()
+                            )).build()
+            ).toList();
+        }
+        return TasksDto.builder().tasks(taskItems).build();
     }
 }

--- a/src/main/java/nutshell/server/service/taskStatus/TaskStatusRetriever.java
+++ b/src/main/java/nutshell/server/service/taskStatus/TaskStatusRetriever.java
@@ -3,6 +3,7 @@ package nutshell.server.service.taskStatus;
 import lombok.RequiredArgsConstructor;
 import nutshell.server.domain.Task;
 import nutshell.server.domain.TaskStatus;
+import nutshell.server.domain.User;
 import nutshell.server.dto.type.Status;
 import nutshell.server.exception.NotFoundException;
 import nutshell.server.exception.code.NotFoundErrorCode;
@@ -52,5 +53,13 @@ public class TaskStatusRetriever {
             final LocalDate targetDate
     ) {
         return taskStatusRepository.findAllByTargetDate(targetDate);
+    }
+
+    public List<TaskStatus> findAllByTargetDateAndStatusDesc(
+            final User user,
+            final LocalDate targetDate,
+            final Status status
+    ) {
+        return taskStatusRepository.findAllByTargetDateAndStatusDesc(user, targetDate, status);
     }
 }


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #62 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
Task List 조회 API를 구현했습니다.

Staging Area인 경우, isTotal 에 따라 전체, 지연 조회를 하고, order에 따라 정렬 기준을 다르게 나타냅니다.
TargetDate Area인 경우, 정렬을 위해 첫번째 값으로 최근에 status가 업데이트순으로 정렬하고, 그 뒤로 assign된 순으로 정렬하도록 합니다.
다른 내용은 전 pr에서 자세히 했기 때문에 생략하겠습니다.

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
