### PR TITLE
[feat] task 수정 시 마다 timeBlock cascade를 통한 삭제 및 추가 삭제 로직 구현

### DIFF
--- a/src/main/java/nutshell/server/domain/Task.java
+++ b/src/main/java/nutshell/server/domain/Task.java
@@ -54,9 +54,6 @@ public class Task {
     @JoinColumn(name="user_id", nullable = false)
     private User user;
 
-    @OneToMany(mappedBy="task", fetch=FetchType.LAZY, cascade=CascadeType.ALL)
-    private List<TimeBlock> timeBlocks;
-
     @OneToMany(mappedBy = "task", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<TaskStatus> taskStatuses;
 

--- a/src/main/java/nutshell/server/domain/Task.java
+++ b/src/main/java/nutshell/server/domain/Task.java
@@ -50,11 +50,11 @@ public class Task {
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
 
-    @ManyToOne(targetEntity= User.class, fetch=FetchType.LAZY)
+    @ManyToOne(targetEntity = User.class, fetch = FetchType.LAZY)
     @JoinColumn(name="user_id", nullable = false)
     private User user;
 
-    @OneToMany(mappedBy = "task", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "task", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     private List<TaskStatus> taskStatuses;
 
     @Builder

--- a/src/main/java/nutshell/server/domain/TaskStatus.java
+++ b/src/main/java/nutshell/server/domain/TaskStatus.java
@@ -35,7 +35,7 @@ public class TaskStatus {
     @JoinColumn(name="task_id", nullable = false)
     private Task task;
 
-    @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY, mappedBy = "taskStatus")
+    @OneToOne(cascade = CascadeType.REMOVE, fetch = FetchType.LAZY, mappedBy = "taskStatus")
     private TimeBlock timeBlock;
 
     @Builder

--- a/src/main/java/nutshell/server/domain/TaskStatus.java
+++ b/src/main/java/nutshell/server/domain/TaskStatus.java
@@ -51,8 +51,4 @@ public class TaskStatus {
         this.status = status;
         this.updatedAt = LocalDateTime.now();
     }
-
-    public void updateTimeBlock(){
-        this.timeBlock = null;
-    }
 }

--- a/src/main/java/nutshell/server/domain/TaskStatus.java
+++ b/src/main/java/nutshell/server/domain/TaskStatus.java
@@ -35,6 +35,9 @@ public class TaskStatus {
     @JoinColumn(name="task_id", nullable = false)
     private Task task;
 
+    @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY, mappedBy = "taskStatus")
+    private TimeBlock timeBlock;
+
     @Builder
     public TaskStatus(Status status, Task task, LocalDate targetDate) {
         this.status = status;
@@ -47,5 +50,9 @@ public class TaskStatus {
     public void updateStatus(Status status) {
         this.status = status;
         this.updatedAt = LocalDateTime.now();
+    }
+
+    public void updateTimeBlock(){
+        this.timeBlock = null;
     }
 }

--- a/src/main/java/nutshell/server/domain/TimeBlock.java
+++ b/src/main/java/nutshell/server/domain/TimeBlock.java
@@ -6,7 +6,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Entity
@@ -29,15 +28,15 @@ public class TimeBlock {
     @Column(name="updated_at", nullable = false)
     private LocalDateTime updatedAt;
 
-    @ManyToOne(targetEntity= Task.class, fetch=FetchType.LAZY)
-    @JoinColumn(name="task_id", nullable = false)
-    private Task task;
+    @OneToOne(targetEntity = TaskStatus.class, fetch = FetchType.LAZY)
+    @JoinColumn(name = "task_status_id", nullable = false)
+    private TaskStatus taskStatus;
 
     @Builder
-    public TimeBlock(LocalDateTime startTime, LocalDateTime endTime, Task task) {
+    public TimeBlock(LocalDateTime startTime, LocalDateTime endTime, TaskStatus taskStatus) {
         this.startTime = startTime;
         this.endTime = endTime;
-        this.task = task;
+        this.taskStatus = taskStatus;
         this.createdAt = LocalDateTime.now();
         this.updatedAt = LocalDateTime.now();
     }

--- a/src/main/java/nutshell/server/domain/User.java
+++ b/src/main/java/nutshell/server/domain/User.java
@@ -39,10 +39,10 @@ public class User {
     @Column(name="updated_at", nullable = false)
     private LocalDateTime updatedAt;
 
-    @OneToMany(mappedBy="user", fetch=FetchType.LAZY, cascade=CascadeType.ALL)
+    @OneToMany(mappedBy="user", fetch = FetchType.LAZY, cascade=CascadeType.REMOVE)
     private List<Task> tasks;
 
-    @OneToMany(mappedBy="user", fetch=FetchType.LAZY, cascade=CascadeType.ALL)
+    @OneToMany(mappedBy="user", fetch = FetchType.LAZY, cascade=CascadeType.REMOVE)
     private List<GoogleCalendar> googleCalendars;
 
     @Builder

--- a/src/main/java/nutshell/server/repository/TaskRepository.java
+++ b/src/main/java/nutshell/server/repository/TaskRepository.java
@@ -14,7 +14,7 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
 
     @Query(value="select t from Task t where t.user = :user " +
             "and exists (select tb from TimeBlock tb " +
-            "where tb.task = t and tb.startTime between :startTime and :endTime " +
+            "where tb.taskStatus.task = t and tb.startTime between :startTime and :endTime " +
             "and tb.endTime between :startTime and :endTime)")
     List<Task> findAllByUserAndTimeBlocks(final User user, LocalDateTime startTime, LocalDateTime endTime);
 

--- a/src/main/java/nutshell/server/repository/TaskStatusRepository.java
+++ b/src/main/java/nutshell/server/repository/TaskStatusRepository.java
@@ -36,6 +36,6 @@ public interface TaskStatusRepository extends JpaRepository<TaskStatus, Long> {
     List<TaskStatus> findAllByTargetDate(final LocalDate targetDate);
 
     @Query(value = "select ts from TaskStatus ts where ts.task.user = :user and ts.targetDate = :targetDate " +
-            "and ts.status = :status order by ts.updatedAt desc, ts.task.assignedDate desc")
+            "and ts.status = :status order by ts.updatedAt desc, ts.createdAt desc")
     List<TaskStatus> findAllByTargetDateAndStatusDesc(final User user, final LocalDate targetDate, final Status status);
 }

--- a/src/main/java/nutshell/server/repository/TimeBlockRepository.java
+++ b/src/main/java/nutshell/server/repository/TimeBlockRepository.java
@@ -15,8 +15,8 @@ import java.util.Optional;
 public interface TimeBlockRepository extends JpaRepository<TimeBlock, Long> {
     @Query(value="select count(t) > 0 from TimeBlock t " +
             "where t.taskStatus.task.user = :user and " +
-            "t.startTime between :startTime and :endTime or " +
-            "t.endTime between :startTime and :endTime"
+            "((t.startTime > :startTime and t.startTime < :endTime) or " +
+            "(t.endTime > :startTime and t.endTime < :endTime))"
             )
     Boolean existsByTaskUserAndStartTimeBetweenAndEndTimeBetween(
             final User user,
@@ -27,8 +27,8 @@ public interface TimeBlockRepository extends JpaRepository<TimeBlock, Long> {
     @Query(value="select count(t) > 0 from TimeBlock t " +
             "where t.taskStatus.task.user = :user and " +
             "t.id != :id and " +
-            "(t.startTime between :startTime and :endTime or " +
-            "t.endTime between :startTime and :endTime)"
+            "((t.startTime > :startTime and t.endTime < :endTime) or " +
+            "(t.endTime > :startTime and t.endTime < :endTime))"
     )
     Boolean existsByTaskUserAndStartTimeBetweenAndEndTimeBetweenAndIdNot(
             final User user,

--- a/src/main/java/nutshell/server/repository/TimeBlockRepository.java
+++ b/src/main/java/nutshell/server/repository/TimeBlockRepository.java
@@ -1,6 +1,7 @@
 package nutshell.server.repository;
 
 import nutshell.server.domain.Task;
+import nutshell.server.domain.TaskStatus;
 import nutshell.server.domain.TimeBlock;
 import nutshell.server.domain.User;
 import nutshell.server.dto.timeBlock.response.TimeBlockDto;
@@ -13,7 +14,7 @@ import java.util.Optional;
 
 public interface TimeBlockRepository extends JpaRepository<TimeBlock, Long> {
     @Query(value="select count(t) > 0 from TimeBlock t " +
-            "where t.task.user = :user and " +
+            "where t.taskStatus.task.user = :user and " +
             "t.startTime between :startTime and :endTime or " +
             "t.endTime between :startTime and :endTime"
             )
@@ -24,7 +25,7 @@ public interface TimeBlockRepository extends JpaRepository<TimeBlock, Long> {
     );
 
     @Query(value="select count(t) > 0 from TimeBlock t " +
-            "where t.task.user = :user and " +
+            "where t.taskStatus.task.user = :user and " +
             "t.id != :id and " +
             "(t.startTime between :startTime and :endTime or " +
             "t.endTime between :startTime and :endTime)"
@@ -36,18 +37,21 @@ public interface TimeBlockRepository extends JpaRepository<TimeBlock, Long> {
             final LocalDateTime endTime
     );
 
+    @Query(value="select exists(select t from TimeBlock t " +
+            "where t.taskStatus.task = :task and " +
+            "t.startTime between :startTime and :endTime and " +
+            "t.endTime between :startTime and :endTime)"
+    )
     Boolean existsByTaskAndStartTimeBetweenAndEndTimeBetween(
             final Task task,
             final LocalDateTime startTime,
-            final LocalDateTime endTime,
-            final LocalDateTime startTime2,
-            final LocalDateTime endTime2
+            final LocalDateTime endTime
     );
 
 
     @Query("SELECT new nutshell.server.dto.timeBlock.response.TimeBlockDto(t.id, t.startTime, t.endTime) " +
             "FROM TimeBlock t " +
-            "WHERE t.task = :task " +
+            "WHERE t.taskStatus.task = :task " +
             "AND t.startTime between :startTime and :endTime " +
             "AND t.endTime between :startTime and :endTime")
     List<TimeBlockDto> findAllByTaskIdAndTimeRange(
@@ -56,11 +60,14 @@ public interface TimeBlockRepository extends JpaRepository<TimeBlock, Long> {
             final LocalDateTime endTime
     );
 
+    @Query(value = "SELECT t from TimeBlock t WHERE t.taskStatus.task = :task AND t.id = :id")
     Optional<TimeBlock> findByTaskAndId(final Task task, final Long id);
 
-    @Query( value = "SELECT t from TimeBlock t WHERE t.task = :task " +
+    @Query( value = "SELECT t from TimeBlock t WHERE t.taskStatus.task = :task " +
             "AND t.startTime >= :startOfDay AND t.startTime <= :endOfDay " +
             "AND t.endTime >= :startOfDay AND t.endTime <= :endOfDay"
     )
     Optional<TimeBlock> findByTaskIdAndTargetDate(final Task task, final LocalDateTime startOfDay, final LocalDateTime endOfDay);
+
+    Optional<TimeBlock> findByTaskStatus(final TaskStatus taskStatus);
 }

--- a/src/main/java/nutshell/server/service/task/TaskService.java
+++ b/src/main/java/nutshell/server/service/task/TaskService.java
@@ -104,8 +104,6 @@ public class TaskService {
             );
             if (status.equals(Status.DEFERRED)) {
                 TimeBlock timeBlock = timeBlockRetriever.findByTaskStatus(taskStatus);
-                //영속성을 끊어주기 위해서 taskStatus의 timeBlock을 null로 변경
-                taskStatus.updateTimeBlock();
                 timeBlockRemover.remove(timeBlock);
             }
             taskStatusUpdater.updateStatus(taskStatus, status);

--- a/src/main/java/nutshell/server/service/task/TaskService.java
+++ b/src/main/java/nutshell/server/service/task/TaskService.java
@@ -106,7 +106,7 @@ public class TaskService {
                 TimeBlock timeBlock = timeBlockRetriever.findByTaskStatus(taskStatus);
                 //영속성을 끊어주기 위해서 taskStatus의 timeBlock을 null로 변경
                 taskStatus.updateTimeBlock();
-                timeBlockRemover.removeById(timeBlock.getId());
+                timeBlockRemover.remove(timeBlock);
             }
             taskStatusUpdater.updateStatus(taskStatus, status);
         }

--- a/src/main/java/nutshell/server/service/timeBlock/TimeBlockRemover.java
+++ b/src/main/java/nutshell/server/service/timeBlock/TimeBlockRemover.java
@@ -4,13 +4,19 @@ import lombok.RequiredArgsConstructor;
 import nutshell.server.domain.TimeBlock;
 import nutshell.server.repository.TimeBlockRepository;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
 public class TimeBlockRemover {
     private final TimeBlockRepository timeBlockRepository;
 
+    @Transactional
     public void remove(final TimeBlock timeBlock) {
         timeBlockRepository.delete(timeBlock);
+    }
+
+    public void removeById(final Long id) {
+        timeBlockRepository.deleteById(id);
     }
 }

--- a/src/main/java/nutshell/server/service/timeBlock/TimeBlockRemover.java
+++ b/src/main/java/nutshell/server/service/timeBlock/TimeBlockRemover.java
@@ -15,8 +15,4 @@ public class TimeBlockRemover {
     public void remove(final TimeBlock timeBlock) {
         timeBlockRepository.delete(timeBlock);
     }
-
-    public void removeById(final Long id) {
-        timeBlockRepository.deleteById(id);
-    }
 }

--- a/src/main/java/nutshell/server/service/timeBlock/TimeBlockRetriever.java
+++ b/src/main/java/nutshell/server/service/timeBlock/TimeBlockRetriever.java
@@ -2,6 +2,7 @@ package nutshell.server.service.timeBlock;
 
 import lombok.RequiredArgsConstructor;
 import nutshell.server.domain.Task;
+import nutshell.server.domain.TaskStatus;
 import nutshell.server.domain.TimeBlock;
 import nutshell.server.domain.User;
 import nutshell.server.dto.timeBlock.response.TimeBlockDto;
@@ -55,7 +56,7 @@ public class TimeBlockRetriever {
             final LocalDateTime startTime,
             final LocalDateTime endTime
     ) {
-        return timeBlockRepository.existsByTaskAndStartTimeBetweenAndEndTimeBetween(task, startTime, endTime, startTime, endTime);
+        return timeBlockRepository.existsByTaskAndStartTimeBetweenAndEndTimeBetween(task, startTime, endTime);
     }
 
     public List<TimeBlockDto> findAllByTaskIdAndTimeRange(
@@ -64,5 +65,11 @@ public class TimeBlockRetriever {
             final LocalDateTime endTime
     ) {
         return timeBlockRepository.findAllByTaskIdAndTimeRange(task, startTime, endTime);
+    }
+
+    public TimeBlock findByTaskStatus(
+            final TaskStatus taskStatus
+    ){
+        return timeBlockRepository.findByTaskStatus(taskStatus).orElse(null);
     }
 }


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #70

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
timeBlock을 taskstatus의 변경 시 마다 삭제를 해주기 위해서 매핑을 task(다대일)에서 taskStatus(일대일)로 바꿨습니다. 그 후 cascade를 걸어서 taskStatus가 삭제 될 때 timeBlock도 함께 삭제되도록 해주었습니다.
## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->
OneToOne 관계인 TaskStatus와 TimeBlock을 동시에 수정 및 삭제를 진행하는 과정에서 TimeBlock이 삭제가 안되던 문제가 있었습니다. 찾아본 결과 TaskStatus에서 TimeBlock의 Mapping을 매핑해주는 곳에서 CascadeType을 ALL로 설정을 하여 영속성 엔티티 문제로 인해서 삭제가 되지 않던 것이였습니다. 그래서 영속성을 해제해주기 위해서 CascadeType을 REMOVE만 걸어주어서 TaskStatus가 삭제될 때에만 cascade가 설정되게 하였고, 이렇게 수정하니 정상적으로 TimeBlock이 삭제되었습니다.
## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
