### PR TITLE
[feat] 대시보드에서 기간별로 완료한 일 수, 평균 진행 중인 일 수, 평균 지연율을 조회하는 GET API 구현

### DIFF
--- a/src/main/java/nutshell/server/controller/TaskController.java
+++ b/src/main/java/nutshell/server/controller/TaskController.java
@@ -81,9 +81,8 @@ public class TaskController {
             @UserId final Long userId,
             @RequestParam(required = false) final LocalDate startDate,
             @RequestParam(required = false) final LocalDate endDate,
-            @RequestParam(required = false) final Boolean isMonth,
-            @RequestParam(required = false) final Boolean isWeek
+            @RequestParam(required = false) final Boolean isMonth
     ){
-        return ResponseEntity.ok(taskService.getDashboard(userId, startDate, endDate, isMonth, isWeek));
+        return ResponseEntity.ok(taskService.getDashboard(userId, startDate, endDate, isMonth));
     }
 }

--- a/src/main/java/nutshell/server/controller/TaskController.java
+++ b/src/main/java/nutshell/server/controller/TaskController.java
@@ -76,4 +76,14 @@ public class TaskController {
         return ResponseEntity.noContent().build();
     }
 
+    @GetMapping("/tasks/period")
+    public ResponseEntity<TaskDashboardDto> showDashboard(
+            @UserId final Long userId,
+            @RequestParam(required = false) final LocalDate startDate,
+            @RequestParam(required = false) final LocalDate endDate,
+            @RequestParam(required = false) final Boolean isMonth,
+            @RequestParam(required = false) final Boolean isWeek
+    ){
+        return ResponseEntity.ok(taskService.getDashboard(userId, startDate, endDate, isMonth, isWeek));
+    }
 }

--- a/src/main/java/nutshell/server/dto/task/TaskDashboardDto.java
+++ b/src/main/java/nutshell/server/dto/task/TaskDashboardDto.java
@@ -1,0 +1,11 @@
+package nutshell.server.dto.task;
+
+import lombok.Builder;
+
+@Builder
+public record TaskDashboardDto(
+        int completeTasks,
+        double avgInprogressTasks,
+        double avgDeferredRate
+) {
+}

--- a/src/main/java/nutshell/server/exception/code/BusinessErrorCode.java
+++ b/src/main/java/nutshell/server/exception/code/BusinessErrorCode.java
@@ -18,6 +18,7 @@ public enum BusinessErrorCode implements DefaultErrorCode{
     DENY_DAY(HttpStatus.OK, "conflict", "해당 날짜에는 작업을 할당할 수 없습니다"),
     BUSINESS_TODAY(HttpStatus.OK, "conflict", "오늘 이전 날짜로는 할당할 수 없습니다"),
     BUSINESS_DUP_DAY(HttpStatus.OK, "conflict", "이미 할당된 날짜입니다"),
+    BUSINESS_PERIOD(HttpStatus.OK,"conflict","기간을 설정해 주세요."),
     ;
     @JsonIgnore
     private final HttpStatus httpStatus;

--- a/src/main/java/nutshell/server/repository/TaskRepository.java
+++ b/src/main/java/nutshell/server/repository/TaskRepository.java
@@ -5,6 +5,7 @@ import nutshell.server.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -37,4 +38,12 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
             , nativeQuery = true
     )
     List<Task> findAllByUserAndAssignedDateIsNullOrderByTimeDiffDesc(final Long userId);
+
+    // 설정한 기간 내의 assigned 된 일들 찾는 거
+    @Query(
+            value = "select count(*) from task t where t.user_id = :userId " +
+                    "AND t.assigned_date BETWEEN :startDate AND :endDate"
+            ,nativeQuery = true
+    )
+    Integer countAllAssignedTasksInPeriod(final Long userId, final LocalDate startDate, final LocalDate endDate);
 }

--- a/src/main/java/nutshell/server/repository/TaskStatusRepository.java
+++ b/src/main/java/nutshell/server/repository/TaskStatusRepository.java
@@ -18,12 +18,14 @@ public interface TaskStatusRepository extends JpaRepository<TaskStatus, Long> {
             final LocalDate targetDate,
             final Status status
     );
+
     //Task를 상속 받고 있고 해당 targetDate를 가지고 있으며 Deferred 상태가 아닌 것이 있는지 반환
     Boolean existsByTaskAndTargetDateAndStatusNot(
             final Task task,
             final LocalDate targetDate,
             final Status status
     );
+
     //Task를 상속 받고 있고 해당 targetDate를 가지고 있으며 Deferred 상태가 아닌 것을 찾아 반환
     Optional<TaskStatus> findByTaskAndTargetDateAndStatusNot(final Task task, final LocalDate targetDate, final Status status);
 
@@ -32,10 +34,17 @@ public interface TaskStatusRepository extends JpaRepository<TaskStatus, Long> {
 
     @Query(value = "select * from task_status ts where ts.target_date = :targetDate " +
             "and ts.status is not 'DEFERRED' and ts.status is not 'DONE'"
-    ,nativeQuery = true)
+            , nativeQuery = true)
     List<TaskStatus> findAllByTargetDate(final LocalDate targetDate);
 
     @Query(value = "select ts from TaskStatus ts where ts.task.user = :user and ts.targetDate = :targetDate " +
             "and ts.status = :status order by ts.updatedAt desc, ts.task.assignedDate desc")
     List<TaskStatus> findAllByTargetDateAndStatusDesc(final User user, final LocalDate targetDate, final Status status);
+
+    // 설정한 기간 내의 'status' 이었던 일들 모두 가져오기
+    @Query(
+            "select count(ts) from TaskStatus ts where ts.task.user = :user and ts.targetDate between :startDate and :endDate " +
+                    "and ts.status = :status"
+    )
+    Integer countAllTasksInPeriod(final User user, final LocalDate startDate, final LocalDate endDate, final Status status);
 }

--- a/src/main/java/nutshell/server/service/task/TaskRetriever.java
+++ b/src/main/java/nutshell/server/service/task/TaskRetriever.java
@@ -8,6 +8,7 @@ import nutshell.server.exception.code.NotFoundErrorCode;
 import nutshell.server.repository.TaskRepository;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -42,5 +43,9 @@ public class TaskRetriever {
 
     public List<Task> findAllByUserAndAssignedDateIsNullOrderByTimeDiffDesc(final User user){
         return taskRepository.findAllByUserAndAssignedDateIsNullOrderByTimeDiffDesc(user.getId());
+    }
+
+    public Integer countAllAssignedTasksInPeriod(final Long userId, final LocalDate startDate, final LocalDate endDate){
+        return taskRepository.countAllAssignedTasksInPeriod(userId, startDate, endDate);
     }
 }

--- a/src/main/java/nutshell/server/service/task/TaskService.java
+++ b/src/main/java/nutshell/server/service/task/TaskService.java
@@ -1,6 +1,7 @@
 package nutshell.server.service.task;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import nutshell.server.domain.Task;
 import nutshell.server.domain.TaskStatus;
 import nutshell.server.domain.TimeBlock;
@@ -20,11 +21,14 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.Period;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class TaskService {
     private final TaskUpdater taskUpdater;
     private final TaskRetriever taskRetriever;
@@ -49,13 +53,17 @@ public class TaskService {
         Status status = Status.fromContent(taskStatusDto.status());
         if (task.getAssignedDate() == null) {   //staging area에서 할당될 때
             if (status == Status.TODO) {
-                if (taskStatusDto.targetDate().isBefore(LocalDate.now()))
+                if (taskStatusDto.targetDate().isBefore(LocalDate.now())) // 할당 하려는 날짜가 now 보다 이전이면 예외
                     throw new BusinessException(BusinessErrorCode.BUSINESS_TODAY);
-            } else if (status != Status.DONE){
+            } else if (status != Status.DONE) { // 완료랑 미완료만 staging area에서 가질 수 있으므로, 아니면 예외
                 throw new IllegalArgumentException(IllegalArgumentErrorCode.INVALID_ARGUMENTS);
             }
+
+            // targetDate에 해당하는 TaskStatus가 이미 존재하는지 확인하고, 존재하면 예외
             if (taskStatusRetriever.existsByTaskAndTargetDate(task, taskStatusDto.targetDate()))
                 throw new BusinessException(BusinessErrorCode.BUSINESS_DUP_DAY);
+
+            // task의 assignedDate를 targetDate로 업데이트하고, 새로운 TaskStatus를 저장
             taskUpdater.updateAssignedDate(task, taskStatusDto.targetDate());
             taskStatusSaver.save(
                     TaskStatus.builder()
@@ -107,14 +115,14 @@ public class TaskService {
     }
 
     @Transactional
-    public Task createTask(final Long userId, final TaskCreateDto taskCreateDto){
+    public Task createTask(final Long userId, final TaskCreateDto taskCreateDto) {
         User user = userRetriever.findByUserId(userId);
 
         LocalDateTime deadLine = null;
         if (taskCreateDto.deadLine() != null) {
             LocalDate date = taskCreateDto.deadLine().date();
 
-            String[] timeParts =  taskCreateDto.deadLine().time().split(":");
+            String[] timeParts = taskCreateDto.deadLine().time().split(":");
             int hour = Integer.parseInt(timeParts[0]);
             int minute = Integer.parseInt(timeParts[1]);
             LocalTime time = LocalTime.of(hour, minute);
@@ -130,13 +138,13 @@ public class TaskService {
         return taskSaver.save(task);
     }
 
-    public void removeTask(final Long userId, final Long taskId){
-        User user= userRetriever.findByUserId(userId);
+    public void removeTask(final Long userId, final Long taskId) {
+        User user = userRetriever.findByUserId(userId);
         Task task = taskRetriever.findByUserAndId(user, taskId);
         taskRemover.deleteTask(task);
     }
 
-    public TaskDto getTaskDetails(final Long userId, final Long taskId, final TargetDateDto targetDateDto){
+    public TaskDto getTaskDetails(final Long userId, final Long taskId, final TargetDateDto targetDateDto) {
         User user = userRetriever.findByUserId(userId);
         Task task = taskRetriever.findByUserAndId(user, taskId);
 
@@ -157,16 +165,16 @@ public class TaskService {
                 .timeBlock(timeBlock)
                 .build();
     }
-  
+
     public TasksDto getTasks(
             final Long userId,
             final Boolean isTotal,
             final String order,
             final LocalDate targetDate
-    ){
+    ) {
         User user = userRetriever.findByUserId(userId);
-        List< TasksDto.TaskItemDto> taskItems;
-        if (targetDate != null){
+        List<TasksDto.TaskItemDto> taskItems;
+        if (targetDate != null) {
             List<TaskStatus> taskStatuses = new ArrayList<>();
             taskStatuses.addAll(taskStatusRetriever.findAllByTargetDateAndStatusDesc(user, targetDate, Status.IN_PROGRESS));
             taskStatuses.addAll(taskStatusRetriever.findAllByTargetDateAndStatusDesc(user, targetDate, Status.TODO));
@@ -211,9 +219,77 @@ public class TaskService {
     }
 
     @Transactional
-    public void editDetail(final Long userId, final Long taskId, TaskDetailEditDto taskDetailEditDto){
+    public void editDetail(final Long userId, final Long taskId, TaskDetailEditDto taskDetailEditDto) {
         User user = userRetriever.findByUserId(userId);
         Task task = taskRetriever.findByUserAndId(user, taskId);
         taskUpdater.editDetails(task, taskDetailEditDto);
+    }
+
+    // 마지막 API
+    public TaskDashboardDto getDashboard(
+            final Long userId,
+            final LocalDate startDate,
+            final LocalDate endDate,
+            final Boolean isMonth,
+            final Boolean isWeek
+    ) {
+        User user = userRetriever.findByUserId(userId);
+
+        int completeTasks = 0; // 완료된 일들
+        int avgInprogressTasks = 0; // 진행 중인 일들
+        int avgDeferredTasks = 0; // 지연된 일들
+        int assignedTasks = 0; // 할당된 일들
+
+        double avgDeferredRate = 0; // 지연카운트 % 기간 내 할당 된 일 개수
+        double avgInprogressDate = 0; // 기간 내 평균 진행 중인 일
+
+        if (startDate != null && endDate != null) {
+            completeTasks = taskStatusRetriever.countAllTasksInPeriod(user, startDate, endDate, Status.DONE); //완료된 할 일 갯수
+            avgInprogressTasks = taskStatusRetriever.countAllTasksInPeriod(user, startDate, endDate, Status.IN_PROGRESS);
+            avgDeferredTasks = taskStatusRetriever.countAllTasksInPeriod(user, startDate, endDate, Status.DEFERRED);
+            assignedTasks = taskRetriever.countAllAssignedTasksInPeriod(userId, startDate, endDate);
+
+            avgInprogressDate = Math.round(((double) avgInprogressTasks / ChronoUnit.DAYS.between(startDate, endDate)) * 10) / 10.0;
+            if (assignedTasks != 0) { // 할당된 작업이 있는 경우에만 계산
+                avgDeferredRate = Math.round(((double) avgDeferredTasks / assignedTasks) * 1000) / 10.0;
+            }
+
+        } else if (isMonth) { // 지난 1달
+            LocalDate now = LocalDate.now().plusDays(1);
+            LocalDate past = now.minusDays(30);
+
+            completeTasks = taskStatusRetriever.countAllTasksInPeriod(user, past, now, Status.DONE);
+            avgInprogressTasks = taskStatusRetriever.countAllTasksInPeriod(user, past, now, Status.IN_PROGRESS);
+            avgDeferredTasks = taskStatusRetriever.countAllTasksInPeriod(user, past, now, Status.DEFERRED);
+            assignedTasks = taskRetriever.countAllAssignedTasksInPeriod(userId, past, now);
+
+            avgInprogressDate = Math.round(((double) avgInprogressTasks / ChronoUnit.DAYS.between(past, now)) * 10);
+            if (assignedTasks != 0) { // 할당된 작업이 있는 경우에만 계산
+                avgDeferredRate = Math.round(((double) avgDeferredTasks / assignedTasks) * 1000) / 10.0;
+            }
+
+        } else if (isWeek) { // 지난 1주일
+            LocalDate nowDay = LocalDate.now().plusDays(1);
+            LocalDate pastDay = nowDay.minusDays(7);
+
+            completeTasks = taskStatusRetriever.countAllTasksInPeriod(user, pastDay, nowDay, Status.DONE);
+            avgInprogressTasks = taskStatusRetriever.countAllTasksInPeriod(user, pastDay, nowDay, Status.IN_PROGRESS);
+            avgDeferredTasks = taskStatusRetriever.countAllTasksInPeriod(user, pastDay, nowDay, Status.DEFERRED);
+            assignedTasks = taskRetriever.countAllAssignedTasksInPeriod(userId, pastDay, nowDay);
+
+            avgInprogressDate = Math.round(((double) avgInprogressTasks / ChronoUnit.DAYS.between(pastDay, nowDay)) * 10) / 10.0;
+            if (assignedTasks != 0) { // 할당된 작업이 있는 경우에만 계산
+                avgDeferredRate = Math.round(((double) avgDeferredTasks / assignedTasks) * 1000) / 10.0;
+            }
+
+        } else {
+            throw new BusinessException(BusinessErrorCode.BUSINESS_PERIOD);
+        }
+
+        return TaskDashboardDto.builder()
+                .completeTasks(completeTasks)
+                .avgInprogressTasks(avgInprogressDate)
+                .avgDeferredRate(avgDeferredRate)
+                .build();
     }
 }

--- a/src/main/java/nutshell/server/service/taskStatus/TaskStatusRetriever.java
+++ b/src/main/java/nutshell/server/service/taskStatus/TaskStatusRetriever.java
@@ -62,4 +62,14 @@ public class TaskStatusRetriever {
     ) {
         return taskStatusRepository.findAllByTargetDateAndStatusDesc(user, targetDate, status);
     }
+
+    // 특정 상태였던 일 가져오기
+    public Integer countAllTasksInPeriod(
+            final User user,
+            final LocalDate startDate,
+            final LocalDate endDate,
+            final Status status
+    ){
+        return taskStatusRepository.countAllTasksInPeriod(user, startDate, endDate, status);
+    }
 }


### PR DESCRIPTION
## Related issue 🛠
<!-- 관련 이슈 번호를 적어주세요 -->
- closes #69 

&nbsp;

## Work Description ✏️
<!-- 작업 내용을 간단히 소개주세요 -->

&nbsp;

### TaskController
https://github.com/TEAM-DAWM/NUTSHELL-SERVER/blob/58f8b7934e9ab43775498298dc6736c905bb5f72/src/main/java/nutshell/server/controller/TaskController.java#L79-L88

&nbsp;

### TaskService
https://github.com/TEAM-DAWM/NUTSHELL-SERVER/blob/58f8b7934e9ab43775498298dc6736c905bb5f72/src/main/java/nutshell/server/service/task/TaskService.java#L229-L294

&nbsp;

---

&nbsp;

### 완료한 할 일 갯수 , 평균 진행 중인 할 일 갯수
https://github.com/TEAM-DAWM/NUTSHELL-SERVER/blob/58f8b7934e9ab43775498298dc6736c905bb5f72/src/main/java/nutshell/server/repository/TaskStatusRepository.java#L44-L50

- 완료한 할 일 갯수 : (특정 기간 내) 완료 상태 가진 할 일 갯수
- 평균 진행 중인 할 일 갯수 : 진행중 상태 가진 할 일 갯수 / 설정한 기간 term

&nbsp;

💡새롭게 알게 된 점
쿼리문으로 바로 갯수를 count 할 수 있구나!

&nbsp;

---
&nbsp;

### 평균 지연율 
- (특정 기간 내) 지연된 할 일 갯수 / assigned 된 일 갯수
assigned_date는 Task에 있으므로 TaskRepository에서 쿼리문을 작성하여 찾았습니다.

&nbsp;

### 실행 결과
![image](https://github.com/user-attachments/assets/22ae6bdb-61c3-4b17-8975-aa7345c566c5)
![image](https://github.com/user-attachments/assets/595bbe46-d1ce-439c-ab0a-14eeb972591f)
![image](https://github.com/user-attachments/assets/e8f454f2-561b-4fec-b4c6-7aec3b074138)
평균 진행중인 일과 평균 지연율은 소숫점 둘째 자리에서 반올림 했습니다!
isMonth는 기획의 명세대로 오늘포함 30일 이전 날짜까지 즉, 오늘이 7월 12일이면 6/13-7/12일 까지의 날짜가 한 달이 됩니다.
계산은,, 셀프,, 

&nbsp;

## To Reviewers 📢
<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
API 끝났어요!!!! 남은 작업도 화이팅