### PR TITLE
[feat] target area에서 staging area로 할당 로직 추가

### DIFF
--- a/src/main/java/nutshell/server/advice/GlobalExceptionHandler.java
+++ b/src/main/java/nutshell/server/advice/GlobalExceptionHandler.java
@@ -11,6 +11,7 @@ import nutshell.server.exception.code.*;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
@@ -60,6 +61,14 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<IllegalArgumentErrorCode> handleException(MethodArgumentNotValidException e) {
         log.error("handleException() in GlobalExceptionHandler throw MethodArgumentNotValidException : {}", e.getMessage());
+        return ResponseEntity
+                .status(IllegalArgumentErrorCode.INVALID_ARGUMENTS.getHttpStatus())
+                .body(IllegalArgumentErrorCode.INVALID_ARGUMENTS);
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<IllegalArgumentErrorCode> handleException(MissingServletRequestParameterException e) {
+        log.error("handleException() in GlobalExceptionHandler throw MissingServletRequestParameterException : {}", e.getMessage());
         return ResponseEntity
                 .status(IllegalArgumentErrorCode.INVALID_ARGUMENTS.getHttpStatus())
                 .body(IllegalArgumentErrorCode.INVALID_ARGUMENTS);

--- a/src/main/java/nutshell/server/constant/AuthConstant.java
+++ b/src/main/java/nutshell/server/constant/AuthConstant.java
@@ -10,6 +10,7 @@ public class AuthConstant {
             "/api/auth/google/login",
             "/swagger-ui/**",
             "/swagger-ui.html",
+            "/api/test/token/**",
     };
     private AuthConstant() {
     }

--- a/src/main/java/nutshell/server/repository/TaskRepository.java
+++ b/src/main/java/nutshell/server/repository/TaskRepository.java
@@ -43,7 +43,6 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
             value = "select * from task t where t.user_id = :userId " +
                     "AND t.assigned_date is null " +
                     "AND t.dead_line <= now() + interval '2 days' " +
-                    "AND t.dead_line >= now() " +
                     "order by t.dead_line asc nulls last"
             ,nativeQuery = true
     )

--- a/src/main/java/nutshell/server/repository/TaskStatusRepository.java
+++ b/src/main/java/nutshell/server/repository/TaskStatusRepository.java
@@ -47,4 +47,6 @@ public interface TaskStatusRepository extends JpaRepository<TaskStatus, Long> {
                     "and ts.status = :status"
     )
     Integer countAllTasksInPeriod(final User user, final LocalDate startDate, final LocalDate endDate, final Status status);
+
+    Boolean existsByTaskAndStatus(Task task, Status status);
 }

--- a/src/main/java/nutshell/server/repository/TaskStatusRepository.java
+++ b/src/main/java/nutshell/server/repository/TaskStatusRepository.java
@@ -49,4 +49,6 @@ public interface TaskStatusRepository extends JpaRepository<TaskStatus, Long> {
     Integer countAllTasksInPeriod(final User user, final LocalDate startDate, final LocalDate endDate, final Status status);
 
     Boolean existsByTaskAndStatus(Task task, Status status);
+
+    List<TaskStatus> findAllByTaskAndStatusNot(Task task, Status status);
 }

--- a/src/main/java/nutshell/server/service/task/TaskService.java
+++ b/src/main/java/nutshell/server/service/task/TaskService.java
@@ -313,7 +313,7 @@ public class TaskService {
             return calcDashBoard(user, startDate, endDate);
 
         } else {
-            throw new BusinessException(BusinessErrorCode.BUSINESS_PERIOD);
+            throw new IllegalArgumentException(IllegalArgumentErrorCode.INVALID_ARGUMENTS);
         }
     }
 

--- a/src/main/java/nutshell/server/service/task/TaskService.java
+++ b/src/main/java/nutshell/server/service/task/TaskService.java
@@ -59,72 +59,78 @@ public class TaskService {
     ) {
         User user = userRetriever.findByUserId(userId);
         Task task = taskRetriever.findByUserAndId(user, taskId);
-        Status status = Status.fromContent(taskStatusDto.status());
-        if (task.getAssignedDate() == null) {   //staging area에서 할당될 때
-            if (status == Status.TODO) {
-                if (taskStatusDto.targetDate().isBefore(LocalDate.now())) // 할당 하려는 날짜가 now 보다 이전이면 예외
-                    throw new BusinessException(BusinessErrorCode.BUSINESS_TODAY);
-            } else if (status != Status.DONE) { // 완료랑 미완료만 staging area에서 가질 수 있으므로, 아니면 예외
+        if (taskStatusDto.targetDate() == null){    //target area에서 staging area로 넘어갈 경우
+            taskUpdater.updateAssignedDate(task, null);
+            if (taskStatusRetriever.existsByTaskAndStatus(task, Status.DEFERRED)){
+                taskUpdater.updateStatus(task, Status.DEFERRED);
+            } else {
+                taskUpdater.updateStatus(task, Status.TODO);
+            }
+        } else {
+            if(taskStatusDto.status() == null)
                 throw new IllegalArgumentException(IllegalArgumentErrorCode.INVALID_ARGUMENTS);
-            }
-
-            // targetDate에 해당하는 TaskStatus가 이미 존재하는지 확인하고, 존재하면 예외
-            if (taskStatusRetriever.existsByTaskAndTargetDate(task, taskStatusDto.targetDate()))
-                throw new BusinessException(BusinessErrorCode.BUSINESS_DUP_DAY);
-
-            // task의 assignedDate를 targetDate로 업데이트하고, 새로운 TaskStatus를 저장
-            taskUpdater.updateAssignedDate(task, taskStatusDto.targetDate());
-            taskStatusSaver.save(
-                    TaskStatus.builder()
-                            .task(task)
-                            .status(status)
-                            .targetDate(taskStatusDto.targetDate())
-                            .build()
-            );
-        } else {    //target date area에서 수정될 때
-            if ((status == Status.DONE || status == Status.IN_PROGRESS)
-                    && taskStatusDto.targetDate().isBefore(LocalDate.now())
-            ) {    //완료 = targetDate 이후 삭제, 진행 중 = targetDate이후 값 변경
-                taskStatusRemover.removeAll(
-                        taskStatusRetriever.findAllByTaskAndTargetDateGreaterThan(
-                                task, taskStatusDto.targetDate()
-                        )
+            Status status = Status.fromContent(taskStatusDto.status());
+            if (task.getAssignedDate() == null) {   //staging area에서 할당될 때
+                if (status == Status.TODO) {
+                    if (taskStatusDto.targetDate().isBefore(LocalDate.now())) // 할당 하려는 날짜가 now 보다 이전이면 예외
+                        throw new BusinessException(BusinessErrorCode.BUSINESS_TODAY);
+                } else if (status != Status.DONE) { // 완료랑 미완료만 staging area에서 가질 수 있으므로, 아니면 예외
+                    throw new IllegalArgumentException(IllegalArgumentErrorCode.INVALID_ARGUMENTS);
+                }
+                // task의 assignedDate를 targetDate로 업데이트하고, 새로운 TaskStatus를 저장
+                taskUpdater.updateAssignedDate(task, taskStatusDto.targetDate());
+                taskStatusSaver.save(
+                        TaskStatus.builder()
+                                .task(task)
+                                .status(status)
+                                .targetDate(taskStatusDto.targetDate())
+                                .build()
                 );
-                if (status == Status.IN_PROGRESS) {
-                    List<TaskStatus> taskStatuses = new ArrayList<>();
-                    for (LocalDate date = taskStatusDto.targetDate().plusDays(1);
-                         date.isBefore(LocalDate.now().plusDays(1));
-                         date = date.plusDays(1)
-                    ) {
-                        taskStatuses.add(
-                                TaskStatus.builder()
-                                        .task(task)
-                                        .status(status)
-                                        .targetDate(date)
-                                        .build()
-                        );
+            } else {    //target date area에서 수정될 때
+                if ((status.equals(Status.DONE) || status.equals(Status.IN_PROGRESS))
+                        && taskStatusDto.targetDate().isBefore(LocalDate.now())
+                ) {    //완료 = targetDate 이후 삭제, 진행 중 = targetDate이후 값 변경
+                    taskStatusRemover.removeAll(
+                            taskStatusRetriever.findAllByTaskAndTargetDateGreaterThan(
+                                    task, taskStatusDto.targetDate()
+                            )
+                    );
+                    if (status.equals(Status.IN_PROGRESS)) {
+                        List<TaskStatus> taskStatuses = new ArrayList<>();
+                        for (LocalDate date = taskStatusDto.targetDate().plusDays(1);
+                             date.isBefore(LocalDate.now().plusDays(1));
+                             date = date.plusDays(1)
+                        ) {
+                            taskStatuses.add(
+                                    TaskStatus.builder()
+                                            .task(task)
+                                            .status(status)
+                                            .targetDate(date)
+                                            .build()
+                            );
+                        }
+                        taskStatusSaver.saveAll(taskStatuses);
                     }
-                    taskStatusSaver.saveAll(taskStatuses);
+                } else if (status.equals(Status.TODO)) {
+                    taskStatusRemover.removeAll(
+                            taskStatusRetriever.findAllByTask(task, taskStatusDto.targetDate())
+                    );
+                    if (taskStatusDto.targetDate().isBefore(LocalDate.now())) {
+                        status = Status.DEFERRED;
+                        taskUpdater.updateAssignedDate(task, null);
+                    }
                 }
-            } else if (status == Status.TODO) {
-                taskStatusRemover.removeAll(
-                        taskStatusRetriever.findAllByTask(task, taskStatusDto.targetDate())
+                TaskStatus taskStatus = taskStatusRetriever.findByTaskAndTargetDate(
+                        task, taskStatusDto.targetDate()
                 );
-                if (taskStatusDto.targetDate().isBefore(LocalDate.now())) {
-                    status = Status.DEFERRED;
-                    taskUpdater.updateAssignedDate(task, null);
+                if (status.equals(Status.DEFERRED)) {
+                    TimeBlock timeBlock = timeBlockRetriever.findByTaskStatus(taskStatus);
+                    timeBlockRemover.remove(timeBlock);
                 }
+                taskStatusUpdater.updateStatus(taskStatus, status);
             }
-            TaskStatus taskStatus = taskStatusRetriever.findByTaskAndTargetDate(
-                    task, taskStatusDto.targetDate()
-            );
-            if (status.equals(Status.DEFERRED)) {
-                TimeBlock timeBlock = timeBlockRetriever.findByTaskStatus(taskStatus);
-                timeBlockRemover.remove(timeBlock);
-            }
-            taskStatusUpdater.updateStatus(taskStatus, status);
+            taskUpdater.updateStatus(task, status);
         }
-        taskUpdater.updateStatus(task, status);
     }
 
     @Transactional

--- a/src/main/java/nutshell/server/service/task/TaskService.java
+++ b/src/main/java/nutshell/server/service/task/TaskService.java
@@ -16,10 +16,8 @@ import nutshell.server.dto.task.response.TodoTaskDto;
 import nutshell.server.dto.type.Status;
 import nutshell.server.exception.BusinessException;
 import nutshell.server.exception.IllegalArgumentException;
-import nutshell.server.exception.NotFoundException;
 import nutshell.server.exception.code.BusinessErrorCode;
 import nutshell.server.exception.code.IllegalArgumentErrorCode;
-import nutshell.server.exception.code.NotFoundErrorCode;
 import nutshell.server.service.taskStatus.*;
 import nutshell.server.service.timeBlock.TimeBlockRemover;
 import nutshell.server.service.timeBlock.TimeBlockRetriever;
@@ -280,7 +278,7 @@ public class TaskService {
                 ).build();
             }
             case "deferred" -> tasks = taskRetriever.findAllDeferredTasksByUserWithStatus(userId);
-            default -> throw new NotFoundException(NotFoundErrorCode.NOT_FOUND_TASK_TYPE);
+            default -> throw new IllegalArgumentException(IllegalArgumentErrorCode.INVALID_ARGUMENTS);
         }
         return TodoTaskDto.builder()
                 .tasks(

--- a/src/main/java/nutshell/server/service/task/TaskService.java
+++ b/src/main/java/nutshell/server/service/task/TaskService.java
@@ -1,7 +1,6 @@
 package nutshell.server.service.task;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import nutshell.server.domain.Task;
 import nutshell.server.domain.TaskStatus;
 import nutshell.server.domain.TimeBlock;
@@ -37,7 +36,6 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-@Slf4j
 public class TaskService {
     private final TaskUpdater taskUpdater;
     private final TaskRetriever taskRetriever;

--- a/src/main/java/nutshell/server/service/task/TaskService.java
+++ b/src/main/java/nutshell/server/service/task/TaskService.java
@@ -63,9 +63,17 @@ public class TaskService {
             taskUpdater.updateAssignedDate(task, null);
             if (taskStatusRetriever.existsByTaskAndStatus(task, Status.DEFERRED)){
                 taskUpdater.updateStatus(task, Status.DEFERRED);
+                taskStatusSaver.save(
+                        TaskStatus.builder()
+                                .task(task)
+                                .status(Status.DEFERRED)
+                                .targetDate(LocalDate.now())
+                                .build()
+                );
             } else {
                 taskUpdater.updateStatus(task, Status.TODO);
             }
+            taskStatusRemover.removeAll(taskStatusRetriever.findAllByTask(task));
         } else {
             if(taskStatusDto.status() == null)
                 throw new IllegalArgumentException(IllegalArgumentErrorCode.INVALID_ARGUMENTS);
@@ -113,7 +121,7 @@ public class TaskService {
                     }
                 } else if (status.equals(Status.TODO)) {
                     taskStatusRemover.removeAll(
-                            taskStatusRetriever.findAllByTask(task, taskStatusDto.targetDate())
+                            taskStatusRetriever.findAllByTaskAndTargetDateNot(task, taskStatusDto.targetDate())
                     );
                     if (taskStatusDto.targetDate().isBefore(LocalDate.now())) {
                         status = Status.DEFERRED;

--- a/src/main/java/nutshell/server/service/task/TaskUpdater.java
+++ b/src/main/java/nutshell/server/service/task/TaskUpdater.java
@@ -16,12 +16,14 @@ public class TaskUpdater {
             final Task task,
             final TaskUpdateDto taskUpdateDto
     ) {
-        LocalDate date = taskUpdateDto.deadLine().date();
-        String time = taskUpdateDto.deadLine().time();
+        LocalDateTime deadLine = null;
+        if (taskUpdateDto.deadLine() != null){
+            LocalDate date = taskUpdateDto.deadLine().date();
+            String time = taskUpdateDto.deadLine().time();
 
-        String dateTimeString = date.toString() + "T" + time;
-        LocalDateTime deadLine = LocalDateTime.parse(dateTimeString, DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm"));
-
+            String dateTimeString = date.toString() + "T" + time;
+            deadLine = LocalDateTime.parse(dateTimeString, DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm"));
+        }
         task.updateTask(taskUpdateDto.name(), taskUpdateDto.description(), deadLine);
     }
 

--- a/src/main/java/nutshell/server/service/taskStatus/TaskStatusRetriever.java
+++ b/src/main/java/nutshell/server/service/taskStatus/TaskStatusRetriever.java
@@ -35,11 +35,17 @@ public class TaskStatusRetriever {
         return taskStatusRepository.findAllByTaskAndTargetDateGreaterThanAndStatusNot(task, targetDate, Status.DEFERRED);
     }
 
-    public List<TaskStatus> findAllByTask(
+    public List<TaskStatus> findAllByTaskAndTargetDateNot(
             final Task task,
             final LocalDate targetDate
     ) {
         return taskStatusRepository.findAllByTaskAndStatusNotAndTargetDateNot(task, Status.DEFERRED, targetDate);
+    }
+
+    public List<TaskStatus> findAllByTask(
+            final Task task
+    ) {
+        return taskStatusRepository.findAllByTaskAndStatusNot(task, Status.DEFERRED);
     }
 
     public Boolean existsByTaskAndTargetDate(

--- a/src/main/java/nutshell/server/service/taskStatus/TaskStatusRetriever.java
+++ b/src/main/java/nutshell/server/service/taskStatus/TaskStatusRetriever.java
@@ -72,4 +72,11 @@ public class TaskStatusRetriever {
     ){
         return taskStatusRepository.countAllTasksInPeriod(user, startDate, endDate, status);
     }
+
+    public Boolean existsByTaskAndStatus(
+            final Task task,
+            final Status status
+    ) {
+        return taskStatusRepository.existsByTaskAndStatus(task, status);
+    }
 }

--- a/src/main/java/nutshell/server/service/timeBlock/TimeBlockService.java
+++ b/src/main/java/nutshell/server/service/timeBlock/TimeBlockService.java
@@ -71,7 +71,7 @@ public class TimeBlockService {
         }
         if (!taskStatusRetriever.existsByTaskAndTargetDate(task, timeBlockRequestDto.startTime().toLocalDate())) {
             if (timeBlockRequestDto.startTime().toLocalDate().isAfter(LocalDate.now().minusDays(1)) && task.getStatus() == Status.TODO) {
-                taskStatusRemover.removeAll(taskStatusRetriever.findAllByTask(task, timeBlockRequestDto.startTime().toLocalDate()));
+                taskStatusRemover.removeAll(taskStatusRetriever.findAllByTaskAndTargetDateNot(task, timeBlockRequestDto.startTime().toLocalDate()));
                 taskStatusSaver.save(
                         TaskStatus.builder()
                                 .task(task)


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #82 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
task status 수정 api에서 targetDate와 status가 null로 들어오는 경우 target area에서 staging area로 넘겨주는 로직을 추가하였습니다.

```java
        if (taskStatusDto.targetDate() == null){    //target area에서 staging area로 넘어갈 경우
            taskUpdater.updateAssignedDate(task, null);
            if (taskStatusRetriever.existsByTaskAndStatus(task, Status.DEFERRED)){
                taskUpdater.updateStatus(task, Status.DEFERRED);
                taskStatusSaver.save(
                        TaskStatus.builder()
                                .task(task)
                                .status(Status.DEFERRED)
                                .targetDate(LocalDate.now())
                                .build()
                );
            } else {
                taskUpdater.updateStatus(task, Status.TODO);
            }
            taskStatusRemover.removeAll(taskStatusRetriever.findAllByTask(task));
        }
```
이미 한 번 이상 지연으로 바뀐 적 있을 경우에는 바로 지연 상태로 바꿔주고, 아닐 경우 미완료로 바꿔줍니다. 그리고 assignedDate를 null로 바꿔주어 staging area로 갈 수 있도록 해준 후 지연을 제외한 모든 taskStatus를 지워줍니다.
## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
