### PR TITLE
[feat] swagger 인터페이스 작성

### DIFF
--- a/src/main/java/nutshell/server/constant/AuthConstant.java
+++ b/src/main/java/nutshell/server/constant/AuthConstant.java
@@ -8,6 +8,7 @@ public class AuthConstant {
     public static final String[] AUTH_WHITELIST = {
             "/actuator/health",
             "/api/auth/google/login",
+            "/v3/api-docs/**",
             "/swagger-ui/**",
             "/swagger-ui.html",
     };

--- a/src/main/java/nutshell/server/controller/TimeBlockController.java
+++ b/src/main/java/nutshell/server/controller/TimeBlockController.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import nutshell.server.annotation.UserId;
+import nutshell.server.controller.swagger.TimeBlockControllerSwagger;
 import nutshell.server.dto.googleCalender.request.CategoriesDto;
 import nutshell.server.dto.timeBlock.request.TimeBlockRequestDto;
 import nutshell.server.dto.timeBlock.response.TimeBlocksWithGooglesDto;
@@ -17,9 +18,10 @@ import java.time.LocalDate;
 @RestController
 @RequestMapping("/api/tasks")
 @RequiredArgsConstructor
-public class TimeBlockController {
+public class TimeBlockController implements TimeBlockControllerSwagger {
     private final TimeBlockService timeBlockService;
 
+    @Override
     @PostMapping("/{taskId}/time-blocks")
     public ResponseEntity<Void> createTimeBlock(
             @UserId final Long userId,

--- a/src/main/java/nutshell/server/controller/UserController.java
+++ b/src/main/java/nutshell/server/controller/UserController.java
@@ -2,6 +2,7 @@ package nutshell.server.controller;
 
 import lombok.RequiredArgsConstructor;
 import nutshell.server.annotation.UserId;
+import nutshell.server.controller.swagger.UserControllerSwagger;
 import nutshell.server.dto.user.response.UserDto;
 import nutshell.server.service.user.UserService;
 import org.springframework.http.ResponseEntity;
@@ -12,11 +13,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/users")
-public class UserController {
+public class UserController implements UserControllerSwagger {
     private final UserService userService;
 
+    @Override
     @GetMapping
     public ResponseEntity<UserDto> getUser(@UserId final Long userId){
         return ResponseEntity.ok(userService.getUser(userId));
     }
+
 }

--- a/src/main/java/nutshell/server/controller/swagger/TimeBlockControllerSwagger.java
+++ b/src/main/java/nutshell/server/controller/swagger/TimeBlockControllerSwagger.java
@@ -1,0 +1,73 @@
+package nutshell.server.controller.swagger;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import nutshell.server.annotation.UserId;
+import nutshell.server.dto.timeBlock.request.TimeBlockRequestDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "TimeBlock", description = "[TimeBlockController] TimeBlock 관련 API 입니다.")
+public interface TimeBlockControllerSwagger {
+
+    @Operation(summary = "Task 타임블로킹 생성", description = "드래그를 통해서 Task의 Time Blocking을 생성하는 POST API 입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204 No Content", description = "Success", content = @Content),
+            @ApiResponse(responseCode = "200 Ok", description = "Failure",
+                    content = @Content(mediaType = "application/json",
+                            examples = {
+                                    @ExampleObject(name = "startTime이 endTime보다 늦을 경우", value =
+                                            "{\"code\": \"conflict\", \"data\": null, \"message\": \"시작 시간은 종료 시간 이전이어야 합니다.\"}"),
+                                    @ExampleObject(name = "다른 timeBlock과 겹칠 경우", value =
+                                            "{\"code\": \"conflict\", \"data\": null, \"message\": \"지정된 시간 범위 내에 이미 TimeBlock이 있습니다.\"}"),
+                                    @ExampleObject(name = "같은 날에 해당 task가 이미 timeBlock을 가지고 있을 경우", value =
+                                            "{\"code\": \"conflict\", \"data\": null, \"message\": \"지정된 날짜의 작업에 대한 TimeBlock이 이미 있습니다.\"}"),
+                                    @ExampleObject(name = "timeBlock을 할당할 수 없는 날일 경우", value =
+                                            "{\"code\": \"conflict\", \"data\": null, \"message\": \"지정된 날짜에 대한 TimeBlock을 생성할 수 없습니다.\"}")
+                            }
+                    )
+            ),
+            @ApiResponse(responseCode = "400", description = "Bad Request",
+                    content = @Content(mediaType = "application/json",
+                            examples = {
+                                    @ExampleObject(name = "필요한 값이 들어오지 않았거나 올바르지 않은 값이 들어왔을 경우", value =
+                                            "{\"code\": \"error\", \"data\": null, \"message\": \"인자의 형식이 올바르지 않습니다.\"}"),
+                                    @ExampleObject(name = "올바른 날짜 형식이 아닐 경우", value =
+                                            "{\"code\": \"error\", \"data\": null, \"message\": \"날짜 형식이 올바르지 않습니다.\"}"),
+                            }
+                    )
+            ),
+            @ApiResponse(responseCode = "401", description = "Unauthorized",
+                    content = @Content(mediaType = "application/json", schema = @Schema(example =
+                            "{\"code\": \"error\", \"data\": null, \"message\": \"인증되지 않은 사용자입니다.\"}"))
+            ),
+            @ApiResponse(responseCode = "404", description = "Not Found",
+                    content = @Content(mediaType = "application/json",
+                            examples = {
+                                    @ExampleObject(name = "존재하지 않는 사용자일 경우", value =
+                                            "{\"code\": \"error\", \"data\": null, \"message\": \"존재하지 않는 사용자 입니다.\"}"),
+                                    @ExampleObject(name = "존재하지 않는 task의 task id일 경우", value =
+                                            "{\"code\": \"error\", \"data\": null, \"message\": \"존재하지 않는 Task 입니다.\"}"),
+                                    @ExampleObject(name = "timeBlock을 만들고자 하는 날에 task가 없을 경우", value =
+                                            "{\"code\": \"error\", \"data\": null, \"message\": \"해당기간의 Task를 찾을 수 없습니다.\"}"),
+                            }
+                    )
+            ),
+            @ApiResponse(responseCode = "500", description = "Internal Server Error",
+                    content = @Content(mediaType = "application/json", schema = @Schema(example =
+                            "{\"code\": \"error\", \"data\": null, \"message\": \"서버 내부 오류입니다.\"}"))
+            )
+    })
+    ResponseEntity<Void> createTimeBlock(
+            @UserId final Long userId,
+            @PathVariable final Long taskId,
+            @RequestBody @Valid final TimeBlockRequestDto timeBlockRequestDto
+    );
+}

--- a/src/main/java/nutshell/server/controller/swagger/UserControllerSwagger.java
+++ b/src/main/java/nutshell/server/controller/swagger/UserControllerSwagger.java
@@ -1,4 +1,29 @@
 package nutshell.server.controller.swagger;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import nutshell.server.annotation.UserId;
+import nutshell.server.dto.user.response.UserDto;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "User", description = "[UserController] 유저 관련 API 입니다.")
 public interface UserControllerSwagger {
+
+    @Operation(summary = "유저 정보 조회", description = "Google 사용자 정보를 조회하는 GET API 입니다.")
+    @ApiResponses(
+            {
+                    @ApiResponse(responseCode = "200",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = UserDto.class))),
+
+                    @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다.", content = @Content(mediaType = "application/json")),
+                    @ApiResponse(responseCode = "404", description = "존재하지 않는 사용자 입니다.", content = @Content(mediaType = "application/json")),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.", content = @Content(mediaType = "application/json"))
+            }
+    )
+    ResponseEntity<UserDto> getUser(@UserId final Long userId);
 }


### PR DESCRIPTION
## Related issue 🛠
<!-- 관련 이슈 번호를 적어주세요 -->
- closes #81 

## Work Description ✏️
<!-- 작업 내용을 간단히 소개주세요 -->
- swagger 문서를 보기 위해 필요한 경로를 화이트리스트에 추가했습니다.
- swagger 인터페이스를 따로 작성하여 문서화에 필요한 어노테이션들은 핵심 로직에서 분리하였습니다.
- swagger 접속 시
![image](https://github.com/user-attachments/assets/256e04a1-542e-4616-9e60-c7cdda21dfa1)
![image](https://github.com/user-attachments/assets/03be295f-4170-4d53-a428-f4e0e0c247c4)
하나의 상태코드에 대한 여러개의 응답 예시도 보여줄 수 있습니다.

## Uncompleted Tasks 😅
<!-- 끝내지 못한 작업을 적어주세요 -->
후에 한번에 적용하려니 너어무 많아서.. (너무 노가다라......)
이렇게 할 수 있구나! 를 학습하는 정도로만 몇개만 적용해 보았습니다..^_&,,
Notion 최고..bb..

## To Reviewers 📢
<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
