### PR TITLE
[refac] 잘못된 api 요청 시 에러 코드 수정

### DIFF
--- a/src/main/java/nutshell/server/advice/GlobalExceptionHandler.java
+++ b/src/main/java/nutshell/server/advice/GlobalExceptionHandler.java
@@ -40,11 +40,11 @@ public class GlobalExceptionHandler {
 
     // 존재하지 않는 요청에 대한 예외
     @ExceptionHandler(value={NoHandlerFoundException.class, HttpRequestMethodNotSupportedException.class})
-    public ResponseEntity<NotFoundErrorCode> handleNoPageFoundException(Exception e) {
+    public ResponseEntity<BusinessErrorCode> handleNoPageFoundException(Exception e) {
         log.error("GlobalExceptionHandler catch NoHandlerFoundException : {}", e.getMessage());
         return ResponseEntity
-                .status(NotFoundErrorCode.NOT_FOUND_END_POINT.getHttpStatus())
-                .body(NotFoundErrorCode.NOT_FOUND_END_POINT);
+                .status(BusinessErrorCode.WRONG_ENTRY_POINT.getHttpStatus())
+                .body(BusinessErrorCode.WRONG_ENTRY_POINT);
     }
 
     // 기본 예외

--- a/src/main/java/nutshell/server/exception/code/BusinessErrorCode.java
+++ b/src/main/java/nutshell/server/exception/code/BusinessErrorCode.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum BusinessErrorCode implements DefaultErrorCode{
+    WRONG_ENTRY_POINT(HttpStatus.BAD_REQUEST, "error", "잘못된 요청입니다."),
     TIME_CONFLICT(HttpStatus.OK, "conflict", "시작 시간은 종료 시간 이전이어야 합니다."),
     DUP_TIMEBLOCK_CONFLICT(HttpStatus.OK,"conflict","지정된 시간 범위 내에 이미 TimeBlock이 있습니다."),
     DUP_DAY_TIMEBLOCK_CONFLICT(HttpStatus.OK, "conflict", "지정된 날짜의 작업에 대한 TimeBlock이 이미 있습니다."),

--- a/src/main/java/nutshell/server/exception/code/NotFoundErrorCode.java
+++ b/src/main/java/nutshell/server/exception/code/NotFoundErrorCode.java
@@ -9,7 +9,6 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum NotFoundErrorCode implements DefaultErrorCode{
     NOT_FOUND_TASK(HttpStatus.NOT_FOUND, "error", "존재하지 않는 Task입니다."),
-    NOT_FOUND_END_POINT(HttpStatus.NOT_FOUND, "error", "존재하지 않는 API입니다."),
     NOT_FOUND_GOOGLE_CALENDER(HttpStatus.NOT_FOUND, "error", "존재하지 않는 구글 캘린더 입니다."),
     NOT_FOUND_REFRESH_TOKEN(HttpStatus.NOT_FOUND, "error","RefreshToken을 찾을 수 없습니다."),
     NOT_FOUND_USER(HttpStatus.NOT_FOUND,"error","존재하지 않는 사용자입니다."),

--- a/src/main/java/nutshell/server/exception/code/UnAuthorizedErrorCode.java
+++ b/src/main/java/nutshell/server/exception/code/UnAuthorizedErrorCode.java
@@ -10,7 +10,6 @@ import org.springframework.http.HttpStatus;
 public enum UnAuthorizedErrorCode implements DefaultErrorCode{
     TOKEN_EXPIRED_ERROR(HttpStatus.UNAUTHORIZED, "error", "만료된 토큰입니다."),
     TOKEN_UNKNOWN_ERROR(HttpStatus.UNAUTHORIZED, "error", "인증 토큰이 존재지 않습니다."),
-    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "error", "인증되지 않은 사용자입니다."),
     TOKEN_TYPE_ERROR(HttpStatus.UNAUTHORIZED, "error", "토큰 타입이 잘못되거나 제공되지 않았습니다."),
     TOKEN_MALFORMED_ERROR(HttpStatus.UNAUTHORIZED, "error", "잘못된 형식의 토큰입니다."),
     TOKEN_UNSUPPORTED_ERROR(HttpStatus.UNAUTHORIZED, "error", "지원되지 않는 토큰입니다."),

--- a/src/main/java/nutshell/server/security/filter/JwtExceptionFilter.java
+++ b/src/main/java/nutshell/server/security/filter/JwtExceptionFilter.java
@@ -1,6 +1,7 @@
 package nutshell.server.security.filter;
 
 import lombok.NonNull;
+import nutshell.server.exception.BusinessException;
 import nutshell.server.exception.code.DefaultErrorCode;
 import nutshell.server.exception.code.InternalServerErrorCode;
 import nutshell.server.exception.code.UnAuthorizedErrorCode;
@@ -40,6 +41,8 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
             handleException(request, response, filterChain, UnAuthorizedErrorCode.TOKEN_UNSUPPORTED_ERROR, e);
         } catch (JwtException e) {
             handleException(request, response, filterChain, UnAuthorizedErrorCode.TOKEN_UNKNOWN_ERROR, e);
+        } catch (BusinessException e) {
+            handleException(request, response, filterChain, e.getErrorCode(), e);
         } catch (Exception e) {
             handleException(request, response, filterChain, InternalServerErrorCode.INTERNAL_SERVER_ERROR, e);
         }

--- a/src/main/java/nutshell/server/security/handler/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/nutshell/server/security/handler/JwtAuthenticationEntryPoint.java
@@ -2,8 +2,8 @@ package nutshell.server.security.handler;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import nutshell.server.dto.common.ResponseDto;
+import nutshell.server.exception.code.BusinessErrorCode;
 import nutshell.server.exception.code.DefaultErrorCode;
-import nutshell.server.exception.code.UnAuthorizedErrorCode;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.security.core.AuthenticationException;
@@ -25,7 +25,7 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {  
     ) throws IOException {
         DefaultErrorCode errorCode = (DefaultErrorCode) request.getAttribute("exception");
         if (errorCode == null)
-            errorCode = UnAuthorizedErrorCode.UNAUTHORIZED;
+            errorCode = BusinessErrorCode.WRONG_ENTRY_POINT;
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
         response.setStatus(errorCode.getHttpStatus().value());


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #88 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
없는 api를 요청 시 404가 아닌 400을 반환해줍니다.
바꿔준 이유는 생각도 계속 해보고 서칭도 해본 결과, 404에러가 아닌, 잘못된 요청 400 에러가 더 올바르다고 생각했습니다.
그리고 시큐리티 에러 처리를 잘못해줘서 없는 요청도 401로 뜨던 것을 400으로 바꿔주었습니다. exception이라는 attribute를 set해주고, 만약 null일 경우에도 401 에러를 반환해주었는데, 400에러로 바꾸고, 잘못된 요청이라고 알려주도록 수정했습니다.

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
