### PR TITLE
[refac] 스케줄링 쿼리문 리팩토링

### DIFF
--- a/src/main/java/nutshell/server/repository/TaskStatusRepository.java
+++ b/src/main/java/nutshell/server/repository/TaskStatusRepository.java
@@ -33,7 +33,7 @@ public interface TaskStatusRepository extends JpaRepository<TaskStatus, Long> {
     List<TaskStatus> findAllByTaskAndStatusNotAndTargetDateNot(final Task task, final Status status, final LocalDate targetDate);
 
     @Query(value = "select * from task_status ts where ts.target_date = :targetDate " +
-            "and ts.status is not 'DEFERRED' and ts.status is not 'DONE'"
+            "and ts.status not in ('DEFERRED', 'DONE')"
             , nativeQuery = true)
     List<TaskStatus> findAllByTargetDate(final LocalDate targetDate);
 


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #92 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
taskStatus 중 특정 status들이 아닌 값을 찾기 위해 여러 개의 is not 구절을 사용해서 and로 이어줬었습니다. 하지만 not in을 쓰면 더욱 효율적인 것 같아서 

```java
    @Query(value = "select * from task_status ts where ts.target_date = :targetDate " +
            "and ts.status not in ('DEFERRED', 'DONE')"
            , nativeQuery = true)
    List<TaskStatus> findAllByTargetDate(final LocalDate targetDate);
````
not in을 사용한 쿼리문으로 바꾸어주었습니다.
## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
