### PR TITLE
[feat] 스케줄링 Async 추가

### DIFF
--- a/src/main/java/nutshell/server/config/AsyncConfig.java
+++ b/src/main/java/nutshell/server/config/AsyncConfig.java
@@ -1,0 +1,25 @@
+package nutshell.server.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadPoolExecutor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+    @Bean
+    public Executor taskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(3);
+        executor.setMaxPoolSize(9);
+        executor.setQueueCapacity(18);
+        executor.setThreadNamePrefix("Async-");
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.AbortPolicy());
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/nutshell/server/config/AsyncConfig.java
+++ b/src/main/java/nutshell/server/config/AsyncConfig.java
@@ -14,9 +14,9 @@ public class AsyncConfig {
     @Bean
     public Executor taskExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-        executor.setCorePoolSize(3);
-        executor.setMaxPoolSize(9);
-        executor.setQueueCapacity(18);
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(5);
+        executor.setQueueCapacity(10);
         executor.setThreadNamePrefix("Async-");
         executor.setRejectedExecutionHandler(new ThreadPoolExecutor.AbortPolicy());
         executor.initialize();

--- a/src/main/java/nutshell/server/schedule/ScheduleService.java
+++ b/src/main/java/nutshell/server/schedule/ScheduleService.java
@@ -1,0 +1,34 @@
+package nutshell.server.schedule;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import nutshell.server.service.taskStatus.TaskStatusRetriever;
+import nutshell.server.service.taskStatus.TaskStatusService;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ScheduleService {
+    private final TaskStatusRetriever taskStatusRetriever;
+    private final TaskStatusService taskStatusService;
+
+    @Async
+    @Scheduled(cron = "0 0 0 * * *")
+    public void updateDeferred(){
+        taskStatusRetriever.findAllByTargetDate(LocalDate.now().minusDays(1))
+                .forEach(
+                        taskStatus -> {
+                            try{
+                                taskStatusService.scheduleTasks(taskStatus);
+                            } catch (Exception e){
+                                log.error("Error occurred while updating task status : {}", e.getMessage());
+                            }
+                        }
+                );
+    }
+}

--- a/src/main/java/nutshell/server/service/googleCalendar/GoogleCalendarService.java
+++ b/src/main/java/nutshell/server/service/googleCalendar/GoogleCalendarService.java
@@ -143,7 +143,7 @@ public class GoogleCalendarService {
                 .build();
     }
 
-    private Calendar getCalender(
+    private Calendar getCalendar(
             final GoogleCalendar googleCalendar
     ) {
         Credential credential = new Credential.Builder(BearerToken.authorizationHeaderAccessMethod())
@@ -159,7 +159,7 @@ public class GoogleCalendarService {
     private List<GoogleCategoriesDto.GoogleCategoryDto> getCategories(
             final GoogleCalendar googleCalendar
     ) throws IOException {
-        Calendar calender = getCalender(googleCalendar);
+        Calendar calender = getCalendar(googleCalendar);
         CalendarList calendarList = calender.calendarList().list().execute();
         List<CalendarListEntry> items =  calendarList.getItems();
         List<GoogleCategoriesDto.GoogleCategoryDto> categories = new ArrayList<>();
@@ -184,7 +184,7 @@ public class GoogleCalendarService {
             final CategoriesDto categoriesDto
     ) throws IOException {
         List<GoogleSchedulesDto> schedules = new ArrayList<>();
-        Calendar calender = getCalender(googleCalendar);
+        Calendar calender = getCalendar(googleCalendar);
         CalendarList calendarList = calender.calendarList().list().execute();
         List<CalendarListEntry> items =  calendarList.getItems();
         for (CalendarListEntry calendarListEntry : items) {

--- a/src/main/java/nutshell/server/service/googleCalendar/GoogleCalendarService.java
+++ b/src/main/java/nutshell/server/service/googleCalendar/GoogleCalendarService.java
@@ -91,7 +91,7 @@ public class GoogleCalendarService {
     }
 
     @Transactional
-    public List<GoogleSchedulesDto> getGoogleCalenders(
+    public List<GoogleSchedulesDto> getGoogleCalendars(
             final Long userId,
             final LocalDate startDate,
             final Integer range,

--- a/src/main/java/nutshell/server/service/taskStatus/TaskStatusService.java
+++ b/src/main/java/nutshell/server/service/taskStatus/TaskStatusService.java
@@ -6,8 +6,6 @@ import nutshell.server.domain.TaskStatus;
 import nutshell.server.dto.type.Status;
 import nutshell.server.service.task.TaskRetriever;
 import nutshell.server.service.task.TaskUpdater;
-import org.springframework.scheduling.annotation.Async;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,19 +14,11 @@ import java.time.LocalDate;
 @Service
 @RequiredArgsConstructor
 public class TaskStatusService {
-    private final TaskStatusRetriever taskStatusRetriever;
     private final TaskUpdater taskUpdater;
     private final TaskStatusUpdater taskStatusUpdater;
     private final TaskStatusSaver taskStatusSaver;
     private final TaskRetriever taskRetriever;
 
-    @Scheduled(cron = "0 0 0 * * *")
-    public void updateDeferred(){
-        taskStatusRetriever.findAllByTargetDate(LocalDate.now().minusDays(1))
-                .forEach(this::scheduleTasks);
-    }
-
-    @Async
     @Transactional
     public void scheduleTasks(TaskStatus taskStatus) {
         if (taskStatus.getStatus() == Status.TODO){

--- a/src/main/java/nutshell/server/service/timeBlock/TimeBlockService.java
+++ b/src/main/java/nutshell/server/service/timeBlock/TimeBlockService.java
@@ -146,7 +146,7 @@ public class TimeBlockService {
                                 .timeBlocks(timeBlockRetriever.findAllByTaskIdAndTimeRange(task, startTime, endTime))
                                 .build()
                 ).toList();
-        List<GoogleSchedulesDto> googles = googleCalendarService.getGoogleCalenders(userId, startDate, range, categoriesDto);
+        List<GoogleSchedulesDto> googles = googleCalendarService.getGoogleCalendars(userId, startDate, range, categoriesDto);
         return TimeBlocksWithGooglesDto.builder()
                 .tasks(tasks)
                 .googles(googles)


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #99 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
스케줄링 함수를 비동기로 처리하여 스케줄링 함수가 오래 걸리더라도 다른 api들이 호출될 수 있도록 해주었습니다.
AsyncConfig를 설정해서, 프리티어 요금제에 맞게 적절한 스레드 수를 갖도록 해주었습니다.

또한, 트랜잭션의 위치를 변경시켜주었는데 이유는 각각의 for문은 독립적으로 실행되어야 한다는 생각이 있었기 때문에 밑의 함수로 transaction을 분리하고 난 후 try catch문을 통해서 에러가 나더라도 함수가 끝나지 않도록 해주었습니다.

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
