### PR TITLE
[refac] requestBody 삭제 후 requestParam으로 변경

### DIFF
--- a/src/main/java/nutshell/server/controller/TimeBlockController.java
+++ b/src/main/java/nutshell/server/controller/TimeBlockController.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import nutshell.server.annotation.UserId;
-import nutshell.server.dto.googleCalender.request.CategoriesDto;
 import nutshell.server.dto.timeBlock.request.TimeBlockRequestDto;
 import nutshell.server.dto.timeBlock.response.TimeBlocksWithGooglesDto;
 import nutshell.server.service.timeBlock.TimeBlockService;
@@ -13,6 +12,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
 import java.time.LocalDate;
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/tasks")
@@ -56,8 +56,8 @@ public class TimeBlockController {
             @UserId final Long userId,
             @RequestParam @JsonFormat(pattern = "yyyy-MM-dd", timezone = "Asia/Seoul") final LocalDate startDate,
             @RequestParam final Integer range,
-            @RequestBody(required = false) final CategoriesDto categoriesDto
+            @RequestParam(required = false) final List<String> categories
     ) {
-        return ResponseEntity.ok(timeBlockService.getTimeBlocksWithGoogle(userId, startDate, range, categoriesDto));
+        return ResponseEntity.ok(timeBlockService.getTimeBlocksWithGoogle(userId, startDate, range, categories));
     }
 }

--- a/src/main/java/nutshell/server/dto/googleCalender/request/CategoriesDto.java
+++ b/src/main/java/nutshell/server/dto/googleCalender/request/CategoriesDto.java
@@ -1,8 +1,0 @@
-package nutshell.server.dto.googleCalender.request;
-
-import java.util.List;
-
-public record CategoriesDto(
-        List<String> categories
-) {
-}

--- a/src/main/java/nutshell/server/service/googleCalendar/GoogleCalendarService.java
+++ b/src/main/java/nutshell/server/service/googleCalendar/GoogleCalendarService.java
@@ -14,7 +14,6 @@ import lombok.extern.slf4j.Slf4j;
 import nutshell.server.constant.GoogleConstant;
 import nutshell.server.domain.GoogleCalendar;
 import nutshell.server.domain.User;
-import nutshell.server.dto.googleCalender.request.CategoriesDto;
 import nutshell.server.dto.googleCalender.response.*;
 import nutshell.server.exception.BusinessException;
 import nutshell.server.exception.code.BusinessErrorCode;
@@ -106,7 +105,7 @@ public class GoogleCalendarService {
             final Long userId,
             final LocalDate startDate,
             final Integer range,
-            final CategoriesDto categoriesDto
+            final List<String> categories
     ) {
         User user = userRetriever.findByUserId(userId);
         List<GoogleCalendar> googleCalendars = googleCalendarRetriever.findAllByUser(user);
@@ -114,11 +113,11 @@ public class GoogleCalendarService {
         googleCalendars.forEach(
                 googleCalender -> {
                     try {
-                        schedules.addAll(getEvents(googleCalender, startDate, range, categoriesDto));
+                        schedules.addAll(getEvents(googleCalender, startDate, range, categories));
                     } catch (Exception e) {
                         reissue(googleCalender);
                         try {
-                            schedules.addAll(getEvents(googleCalender, startDate, range, categoriesDto));
+                            schedules.addAll(getEvents(googleCalender, startDate, range, categories));
                         } catch (Exception ex) {
                             log.error("Google Calender Error : {}", ex.getMessage());
                         }
@@ -192,7 +191,7 @@ public class GoogleCalendarService {
             final GoogleCalendar googleCalendar,
             final LocalDate startDate,
             final Integer range,
-            final CategoriesDto categoriesDto
+            final List<String> categories
     ) throws IOException {
         List<GoogleSchedulesDto> schedules = new ArrayList<>();
         Calendar calender = getCalendar(googleCalendar);
@@ -200,7 +199,7 @@ public class GoogleCalendarService {
         List<CalendarListEntry> items =  calendarList.getItems();
         for (CalendarListEntry calendarListEntry : items) {
             String calendarId = calendarListEntry.getId();
-            if (categoriesDto != null && categoriesDto.categories() != null && !categoriesDto.categories().contains(calendarId)) {
+            if (categories != null && categories.contains(calendarId)) {
                 continue;
             }
             String calendars = calendarListEntry.getSummary();

--- a/src/main/java/nutshell/server/service/timeBlock/TimeBlockService.java
+++ b/src/main/java/nutshell/server/service/timeBlock/TimeBlockService.java
@@ -6,7 +6,6 @@ import nutshell.server.domain.Task;
 import nutshell.server.domain.TaskStatus;
 import nutshell.server.domain.TimeBlock;
 import nutshell.server.domain.User;
-import nutshell.server.dto.googleCalender.request.CategoriesDto;
 import nutshell.server.dto.googleCalender.response.GoogleSchedulesDto;
 import nutshell.server.dto.timeBlock.request.TimeBlockRequestDto;
 import nutshell.server.dto.timeBlock.response.TimeBlocksDto;
@@ -133,7 +132,7 @@ public class TimeBlockService {
             final Long userId,
             final LocalDate startDate,
             final Integer range,
-            final CategoriesDto categoriesDto
+            final List<String> categories
     ){
         LocalDateTime startTime = startDate.atStartOfDay();
         LocalDateTime endTime = startDate.plusDays(range-1).atTime(23,59,59);
@@ -146,7 +145,7 @@ public class TimeBlockService {
                                 .timeBlocks(timeBlockRetriever.findAllByTaskIdAndTimeRange(task, startTime, endTime))
                                 .build()
                 ).toList();
-        List<GoogleSchedulesDto> googles = googleCalendarService.getGoogleCalendars(userId, startDate, range, categoriesDto);
+        List<GoogleSchedulesDto> googles = googleCalendarService.getGoogleCalendars(userId, startDate, range, categories);
         return TimeBlocksWithGooglesDto.builder()
                 .tasks(tasks)
                 .googles(googles)


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #108 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
GET 메소드를 requestBody를 지우고 requestParam으로 고쳤습니다.
구글 캘린더의 특정 카테고리를 가져오기 위해 리스트로 카테고리 id를 body로 받아왔지만, requestParam으로 수정해주었습니다,

```java
    @GetMapping("/time-blocks")
    public ResponseEntity<TimeBlocksWithGooglesDto> getTimeBlocks(
            @UserId final Long userId,
            @RequestParam @JsonFormat(pattern = "yyyy-MM-dd", timezone = "Asia/Seoul") final LocalDate startDate,
            @RequestParam final Integer range,
            @RequestParam(required = false) final List<String> categories
    ) {
        return ResponseEntity.ok(timeBlockService.getTimeBlocksWithGoogle(userId, startDate, range, categories));
    }
```
## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
