### PR TITLE
[refac] main 클래스의 @EnableFeignClients 삭제

### DIFF
--- a/src/main/java/nutshell/server/ServerApplication.java
+++ b/src/main/java/nutshell/server/ServerApplication.java
@@ -5,9 +5,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication
-@EnableFeignClients
 @EnableScheduling
+@SpringBootApplication
 public class ServerApplication {
 
 	public static void main(String[] args) {


### PR DESCRIPTION
## Related issue 🛠
<!-- 관련 이슈 번호를 적어주세요 -->
- closes #124 

## Work Description ✏️
<!-- 작업 내용을 간단히 소개주세요 -->

@EnableFeignClients: Spring 애플리케이션에서 Feign 클라이언트를 활성화하는 어노테이션

별도의 FeignConfig 클래스에 @EnableFeignClients를 선언해 두었기 때문에, basePackageClasses = ServerApplication.class 옵션을 통해서 ServerApplication 클래스가 속한 패키지(및 그 하위 패키지)에서 Feign 클라이언트를 검색하도록 설정이 되어 있습니다. 

따라서 ServerApplication 클래스에 있는 @EnableFeignClients 는 불필요하므로 중복을 제거해 주었습니다.



## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
구글 로그인 복습하다가 돌아왔습니당 ㅎㅎ