### PR TITLE
:recycle: [refac] conflict 대신 info 상태 도입

### DIFF
--- a/src/main/java/nutshell/server/controller/TaskController.java
+++ b/src/main/java/nutshell/server/controller/TaskController.java
@@ -21,7 +21,7 @@ import java.time.LocalDate;
 public class TaskController {
     private final TaskService taskService;
 
-    // task 상태 수정 PATCH API
+    // task 상태 수정 area 변경 PATCH API
     @PatchMapping("/tasks/{taskId}/status")
     public ResponseEntity<Void> updateStatus(
             @UserId final Long userId,

--- a/src/main/java/nutshell/server/exception/code/BusinessErrorCode.java
+++ b/src/main/java/nutshell/server/exception/code/BusinessErrorCode.java
@@ -9,18 +9,15 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum BusinessErrorCode implements DefaultErrorCode{
     WRONG_ENTRY_POINT(HttpStatus.BAD_REQUEST, "error", "잘못된 요청입니다."),
-    TIME_CONFLICT(HttpStatus.OK, "conflict", "시작 시간은 종료 시간 이전이어야 합니다."),
-    NOT_SAME_DATE_CONFLICT(HttpStatus.OK, "conflict", "시작 시간과 종료 시간의 날짜가 같아야 합니다."),
-    TIME_INVALID(HttpStatus.OK, "conflict", "시간이 올바르지 않습니다."),
-    DUP_TIMEBLOCK_CONFLICT(HttpStatus.OK,"conflict","지정된 시간 범위 내에 이미 타임 블록이 있습니다."),
-    DUP_DAY_TIMEBLOCK_CONFLICT(HttpStatus.OK, "conflict", "지정된 날짜의 작업에 대한 타임 블록이 이미 있습니다."),
-    DENY_DAY_TIMEBLOCK_CONFLICT(HttpStatus.OK, "conflict", "지정된 날짜에 대한 타임 블록을 생성할 수 없습니다."),
-    DUP_DAY_CONFLICT(HttpStatus.OK, "conflict", "지정된 날짜에 이미 할 일이 할당되어 있습니다."),
-    BUSINESS_TODAY(HttpStatus.OK, "conflict", "오늘 이전 날짜로는 할 일 할당할 수 없습니다."),
-    BUSINESS_PERIOD(HttpStatus.OK,"conflict","올바른 기간을 설정해 주세요."),
+
+    TIME_CONFLICT(HttpStatus.OK, "info", "시작 시간은 종료 시간 이전이어야 합니다."),
+    NOT_SAME_DATE_CONFLICT(HttpStatus.OK, "info", "시작 시간과 종료 시간의 날짜가 같아야 합니다."),
+    TIME_INVALID(HttpStatus.OK, "info", "시간이 올바르지 않습니다."),
+    DUP_TIMEBLOCK_CONFLICT(HttpStatus.OK,"info","지정된 시간 범위 내에 이미 타임 블록이 있습니다."),
+    DUP_DAY_TIMEBLOCK_CONFLICT(HttpStatus.OK, "info", "지정된 날짜의 작업에 대한 타임 블록이 이미 있습니다."),
+
     GOOGLE_SERVER_ERROR(HttpStatus.SERVICE_UNAVAILABLE, "external", "구글 서버 내부 오류입니다."),
-    GOOGLE_SERVER_EXIST(HttpStatus.OK, "conflict", "이미 연동한 구글 계정입니다."),
-    NOT_SAME_UPDATE_DATE(HttpStatus.OK, "conflict", "같은 날에만 수정할 수 있습니다."),
+    GOOGLE_SERVER_EXIST(HttpStatus.OK, "info", "이미 연동한 구글 계정입니다."),
     ;
     @JsonIgnore
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #145 

## Work Description ✏️
<!-- 작업 내용을 간단히 소개주세요 -->
시스템상에서 적용이 불가한 경우는 info 로 처리하도록 합니다. (경고느낌..) 
즉 예를 들어, 시작시간을 종료시간보다 이전으로 설정하면 요청은 가나, 뷰에서 변경사항은 없는 경우와 같습니다.

스프린트 하면서 쓰지 않게된 에러 코드들은 삭제했습니다.
